### PR TITLE
feat: k8s/Helm deployment + GHCR publishing + upstream auto-sync

### DIFF
--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -1,0 +1,53 @@
+name: Publish container image to GHCR
+
+# Builds the Dockerfile's `run` stage (skips the heavy Playwright/Jasmine test
+# stages) and publishes ghcr.io/<owner>/tiddlywiki5. Uses the built-in
+# GITHUB_TOKEN — no DockerHub credentials needed.
+
+on:
+  push:
+    branches: [master]
+    tags: ["v*"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
+      - name: Log in to GHCR
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/tiddlywiki5
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=ref,event=tag
+            type=sha,format=short
+
+      - name: Build and push (run stage only)
+        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
+        with:
+          context: .
+          target: run
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/helm-publish.yml
+++ b/.github/workflows/helm-publish.yml
@@ -1,0 +1,66 @@
+name: Package & Publish Helm Chart
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "helm/**"
+      - ".github/workflows/helm-publish.yml"
+  # Also allow manual publish
+  workflow_dispatch:
+
+jobs:
+  release:
+    name: Helm Chart Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write   # chart-releaser needs to push to gh-pages
+      packages: write   # for the GHCR OCI chart push
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0   # chart-releaser needs full history
+
+      - name: Configure Git
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
+        with:
+          version: "3.14.x"
+
+      # chart-releaser packages charts found in ./helm/,
+      # pushes releases to GitHub Releases, and updates the
+      # index on the gh-pages branch so the repo doubles as a
+      # Helm chart repository.
+      #
+      # Usage after setup:
+      #   helm repo add mibmal https://mibmal.github.io/TiddlyWiki5
+      #   helm repo update
+      #   helm install tiddlywiki mibmal/tiddlywiki
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.6.0
+        with:
+          charts_dir: helm
+          # Skip already-released chart versions instead of failing.
+          skip_existing: true
+        env:
+          CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Also push the chart to GHCR as an OCI artifact (uses GITHUB_TOKEN, no
+      # external secrets). Alternative install method:
+      #   helm install tiddlywiki oci://ghcr.io/mibmal/charts/tiddlywiki
+      - name: Log in to GHCR (OCI)
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Package and push chart to GHCR OCI
+        run: |
+          helm package helm/tiddlywiki --destination /tmp/charts
+          for chart in /tmp/charts/*.tgz; do
+            helm push "$chart" oci://ghcr.io/${{ github.repository_owner }}/charts
+          done

--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -1,0 +1,74 @@
+name: Sync from upstream TiddlyWiki
+
+# Keeps this fork current with TiddlyWiki/TiddlyWiki5 automatically so it does
+# not need manual maintenance. Our additions (helm/, k8s/, Dockerfile, the
+# extra .github/workflows) are new files that don't conflict with upstream code,
+# so a fast-forward/clean merge is the normal case. If a merge conflict occurs,
+# the workflow pushes a branch and opens a PR for manual resolution instead of
+# failing silently.
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"   # weekly, Monday 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout master
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: master
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Merge upstream
+        id: merge
+        run: |
+          git remote add upstream https://github.com/TiddlyWiki/TiddlyWiki5.git
+          git fetch upstream master
+          if git merge --no-edit upstream/master; then
+            echo "conflict=false" >> "$GITHUB_OUTPUT"
+          else
+            git merge --abort
+            echo "conflict=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Push merged master
+        if: steps.merge.outputs.conflict == 'false'
+        run: git push origin master
+
+      # On conflict, push a branch and open a PR for manual review.
+      - name: Prepare conflict branch
+        if: steps.merge.outputs.conflict == 'true'
+        run: |
+          BRANCH="upstream-sync/$(date +%Y%m%d)"
+          git checkout -b "$BRANCH"
+          git merge --no-commit --no-ff upstream/master || true
+          git add -A
+          git commit -m "chore: upstream sync (conflicts to resolve)" || true
+          git push origin "$BRANCH"
+          echo "BRANCH=$BRANCH" >> "$GITHUB_ENV"
+
+      - name: Open conflict PR
+        if: steps.merge.outputs.conflict == 'true'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            await github.rest.pulls.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: "Upstream sync needs manual conflict resolution",
+              head: process.env.BRANCH,
+              base: "master",
+              body: "Automated upstream sync hit conflicts. Resolve and merge."
+            });

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,0 +1,415 @@
+# TiddlyWiki — Docker & Kubernetes
+
+A production-ready container image and Helm chart for running TiddlyWiki5 on Kubernetes.
+
+- **Docker Hub:** `mibmal/tiddlywiki` — [hub.docker.com/r/mibmal/tiddlywiki](https://hub.docker.com/r/mibmal/tiddlywiki)
+- **Helm chart:** `https://mibmal.github.io/TiddlyWiki5`
+- **OCI chart:** `oci://registry-1.docker.io/mibmal/charts/tiddlywiki`
+
+---
+
+## Quick start — Docker
+
+```bash
+# Run the bundled demo wiki (no data volume needed)
+docker run --rm -p 8080:8080 mibmal/tiddlywiki
+# → http://localhost:8080
+
+# Run with a persistent wiki (data survives container restarts)
+docker run -d \
+  --name tiddlywiki \
+  -p 8080:8080 \
+  -v tiddlywiki-data:/data/wiki \
+  mibmal/tiddlywiki \
+  /data/wiki --listen host=0.0.0.0 port=8080
+```
+
+The image is built with `gcr.io/distroless/nodejs22-debian12` — no shell, no package manager, runs as non-root (uid 65532).
+
+---
+
+## Quick start — Helm
+
+### Install
+
+```bash
+helm repo add mibmal https://mibmal.github.io/TiddlyWiki5
+helm repo update
+
+helm install tiddlywiki mibmal/tiddlywiki \
+  --namespace tiddlywiki \
+  --create-namespace
+```
+
+Or via OCI (no `helm repo add` needed):
+
+```bash
+helm install tiddlywiki \
+  oci://registry-1.docker.io/mibmal/charts/tiddlywiki \
+  --namespace tiddlywiki \
+  --create-namespace
+```
+
+### Expose with an Ingress
+
+```bash
+helm upgrade --install tiddlywiki mibmal/tiddlywiki \
+  --namespace tiddlywiki --create-namespace \
+  --set ingress.enabled=true \
+  --set "ingress.hosts[0].host=wiki.example.com" \
+  --set "ingress.tls[0].secretName=tiddlywiki-tls" \
+  --set "ingress.tls[0].hosts[0]=wiki.example.com" \
+  --set "ingress.annotations.cert-manager\.io/cluster-issuer=letsencrypt-prod"
+```
+
+### Uninstall
+
+```bash
+helm uninstall tiddlywiki -n tiddlywiki
+# Note: the PVC is kept by default (helm.sh/resource-policy: keep).
+# Delete manually if you want to remove all data:
+kubectl delete pvc tiddlywiki-data -n tiddlywiki
+```
+
+---
+
+## Configuration reference
+
+All options are in [helm/tiddlywiki/values.yaml](helm/tiddlywiki/values.yaml). Key sections:
+
+### Wiki settings
+
+| Value | Default | Description |
+|---|---|---|
+| `wiki.dataPath` | `/data/wiki` | Path served by TiddlyWiki. Use `/app/editions/server` for the bundled demo. |
+| `wiki.port` | `8080` | Container port |
+| `wiki.pathPrefix` | `""` | Host under a sub-path, e.g. `/wiki` |
+| `wiki.gzip` | `true` | Gzip response compression |
+| `wiki.browserCache` | `true` | ETag-based browser caching |
+
+### Authentication
+
+TiddlyWiki supports three auth modes — pick one:
+
+**1. No auth (public wiki)**
+
+```yaml
+auth:
+  enabled: false
+```
+
+**2. Single username / password**
+
+```yaml
+auth:
+  enabled: true
+  username: admin
+  password: changeme
+  readers: "(authenticated)"
+  writers: "(authenticated)"
+```
+
+**3. Multi-user credentials CSV**
+
+```bash
+# Create a credentials.csv file:
+cat > credentials.csv <<EOF
+username,password
+alice,s3cr3t
+bob,p4ssw0rd
+EOF
+
+kubectl create secret generic wiki-credentials \
+  --from-file=credentials.csv=./credentials.csv \
+  -n tiddlywiki
+```
+
+```yaml
+auth:
+  enabled: true
+  credentialsSecret: wiki-credentials
+  readers: "alice,bob"
+  writers: "alice"
+```
+
+**4. SSO via oauth2-proxy** — see [SSO section](#sso-via-oauth2-proxy) below.
+
+### Persistence
+
+```yaml
+persistence:
+  enabled: true
+  size: 1Gi
+  storageClass: ""          # leave empty for cluster default
+  accessMode: ReadWriteOnce
+```
+
+To use an existing PVC:
+
+```yaml
+persistence:
+  existingClaim: my-existing-pvc
+```
+
+### Resources
+
+```yaml
+resources:
+  requests:
+    memory: 128Mi
+    cpu: 100m
+  limits:
+    memory: 256Mi
+    cpu: 500m
+nodeHeapMb: 192    # Node.js V8 heap cap — keep at ~75% of memory limit
+```
+
+---
+
+## SSO via oauth2-proxy
+
+oauth2-proxy handles the OAuth2/OIDC flow, then forwards requests to TiddlyWiki with `X-Auth-Request-User` set to the logged-in user's identity. TiddlyWiki reads that header and treats the user as authenticated — no passwords stored in Kubernetes.
+
+**Supported providers:** GitHub, Google, Azure AD, Okta, GitLab, and any OIDC-compatible IdP.
+
+### GitHub SSO example
+
+1. Create a GitHub OAuth App at <https://github.com/settings/applications/new>
+   - Homepage URL: `https://wiki.example.com`
+   - Callback URL: `https://wiki.example.com/oauth2/callback`
+
+2. Create the secret:
+
+```bash
+kubectl create secret generic wiki-oauth2 \
+  --from-literal=client-id=YOUR_GITHUB_CLIENT_ID \
+  --from-literal=client-secret=YOUR_GITHUB_CLIENT_SECRET \
+  --from-literal=cookie-secret=$(openssl rand -base64 32) \
+  -n tiddlywiki
+```
+
+3. Install the chart:
+
+```bash
+helm upgrade --install tiddlywiki mibmal/tiddlywiki \
+  --namespace tiddlywiki --create-namespace \
+  --set oauth2Proxy.enabled=true \
+  --set oauth2Proxy.provider=github \
+  --set oauth2Proxy.existingSecret=wiki-oauth2 \
+  --set oauth2Proxy.emailDomain="*" \
+  --set auth.enabled=true \
+  --set auth.readers="(authenticated)" \
+  --set auth.writers="(authenticated)" \
+  --set ingress.enabled=true \
+  --set "ingress.hosts[0].host=wiki.example.com" \
+  --set "ingress.tls[0].secretName=tiddlywiki-tls" \
+  --set "ingress.tls[0].hosts[0]=wiki.example.com"
+```
+
+When `oauth2Proxy.enabled=true`, the Service and Ingress automatically target the proxy port (4180) instead of TiddlyWiki's port (8080). The proxy sits in front and only passes authenticated requests through.
+
+### Restrict to a GitHub org/team
+
+```yaml
+oauth2Proxy:
+  enabled: true
+  provider: github
+  githubOrg: my-org
+  githubTeam: my-org/wiki-users
+  existingSecret: wiki-oauth2
+```
+
+### Google OIDC example
+
+```bash
+kubectl create secret generic wiki-oauth2 \
+  --from-literal=client-id=YOUR_GOOGLE_CLIENT_ID \
+  --from-literal=client-secret=YOUR_GOOGLE_CLIENT_SECRET \
+  --from-literal=cookie-secret=$(openssl rand -base64 32) \
+  -n tiddlywiki
+```
+
+```yaml
+oauth2Proxy:
+  enabled: true
+  provider: oidc
+  oidcIssuerUrl: https://accounts.google.com
+  emailDomain: "yourcompany.com"   # restrict to your domain
+  existingSecret: wiki-oauth2
+```
+
+---
+
+## Plugin injection
+
+Mount custom plugins without rebuilding the image. Plugins are picked up via `TIDDLYWIKI_PLUGIN_PATH`.
+
+**From an inline ConfigMap** (small plugins):
+
+```yaml
+plugins:
+  - name: my-banner
+    data:
+      plugin.info: |
+        {"title":"$:/plugins/custom/my-banner","name":"My Banner","description":"Adds a banner"}
+      banner.tid: |
+        title: $:/plugins/custom/my-banner/banner
+        tags: $:/tags/PageTemplate
+        <div class="my-banner">Hello from a ConfigMap plugin!</div>
+```
+
+**From an existing ConfigMap** (pre-created, e.g. from a large plugin):
+
+```bash
+kubectl create configmap my-plugin \
+  --from-file=plugin.info=./myplugin/plugin.info \
+  --from-file=myplugin.js=./myplugin/myplugin.js \
+  -n tiddlywiki
+```
+
+```yaml
+plugins:
+  - name: my-plugin
+    existingConfigMap: my-plugin
+```
+
+---
+
+## Git backup
+
+Automatically commit and push wiki changes to a git repository on a schedule:
+
+**SSH remote (recommended):**
+
+```bash
+# Generate a deploy key
+ssh-keygen -t ed25519 -f wiki-deploy-key -N ""
+# Add wiki-deploy-key.pub as a deploy key on your backup repo (with write access)
+
+kubectl create secret generic wiki-git-ssh \
+  --from-file=id_rsa=./wiki-deploy-key \
+  -n tiddlywiki
+```
+
+```yaml
+gitSync:
+  enabled: true
+  repoUrl: "git@github.com:youruser/wiki-backup.git"
+  branch: main
+  schedule: "0 * * * *"     # every hour
+  existingSecret: wiki-git-ssh
+```
+
+**HTTPS remote:**
+
+```bash
+kubectl create secret generic wiki-git-https \
+  --from-literal=GIT_USERNAME=youruser \
+  --from-literal=GIT_PASSWORD=ghp_yourtoken \
+  -n tiddlywiki
+```
+
+```yaml
+gitSync:
+  enabled: true
+  repoUrl: "https://github.com/youruser/wiki-backup.git"
+  branch: main
+  existingSecret: wiki-git-https
+```
+
+---
+
+## VolumeSnapshot backups
+
+Create CSI snapshots of the wiki PVC on a schedule (requires a CSI driver that supports `VolumeSnapshot`):
+
+```yaml
+volumeSnapshotBackup:
+  enabled: true
+  schedule: "0 2 * * *"        # 2am daily
+  retentionCount: 7            # keep 7 snapshots
+  snapshotClass: "csi-hostpath-snapclass"   # your cluster's VolumeSnapshotClass
+```
+
+---
+
+## High availability
+
+> **Requires a ReadWriteMany storage class** (NFS, CephFS, AWS EFS, etc.)
+> TiddlyWiki writes files directly to disk — multiple pods sharing a ReadWriteOnce PVC will corrupt data.
+
+```bash
+helm upgrade --install tiddlywiki mibmal/tiddlywiki \
+  --namespace tiddlywiki --create-namespace \
+  -f helm/tiddlywiki/values-ha.yaml \
+  --set persistence.storageClass=nfs-client
+```
+
+The `values-ha.yaml` preset configures:
+- 2 replicas with `RollingUpdate` strategy
+- Hard pod anti-affinity (no two pods on the same node)
+- Zone spreading preference
+- HPA (2–4 replicas, CPU 70% / memory 80%)
+- PodDisruptionBudget (`minAvailable: 1`)
+
+---
+
+## Observability (OpenTelemetry)
+
+Enable the OTEL sidecar collector to forward traces and metrics to any OTLP-compatible backend (Grafana, Jaeger, Tempo, Datadog, etc.):
+
+```bash
+helm upgrade --install tiddlywiki mibmal/tiddlywiki \
+  --namespace tiddlywiki --create-namespace \
+  -f helm/tiddlywiki/values-otel.yaml
+```
+
+Configure your backend in `values-otel.yaml` under `otel.sidecar.config.exporters`.
+
+For **Prometheus Operator** integration:
+
+```yaml
+serviceMonitor:
+  enabled: true
+  interval: 30s
+```
+
+---
+
+## Kustomize
+
+If you prefer Kustomize over Helm:
+
+```bash
+# Dev (NodePort 30080, reduced resources)
+kubectl apply -k k8s/overlays/dev
+
+# Prod (nginx Ingress, cert-manager TLS, retain PVC)
+# Edit k8s/overlays/prod/ingress.yaml to set your domain first
+kubectl apply -k k8s/overlays/prod
+```
+
+---
+
+## Building the image locally
+
+```bash
+docker build -t mibmal/tiddlywiki:dev .
+
+# Test it
+docker run --rm -p 8080:8080 mibmal/tiddlywiki:dev
+```
+
+The CI workflow (`.github/workflows/docker-publish.yml`) builds `linux/amd64` and `linux/arm64` and pushes to Docker Hub on every push to `master` and on version tags (`v*.*.*`).
+
+---
+
+## Image security
+
+- Base: `gcr.io/distroless/nodejs22-debian12` — no shell, no package manager, no setuid binaries
+- Runs as `nonroot` uid 65532 (never root)
+- `readOnlyRootFilesystem: true` — only `/data/wiki` (PVC mount) and `/tmp` (tmpfs) are writable
+- All Linux capabilities dropped
+- `seccompProfile: RuntimeDefault`
+- Pod Security Standards: `restricted` namespace label enforced
+- SBOM and provenance attestations attached to every Docker Hub image

--- a/helm/tiddlywiki/Chart.yaml
+++ b/helm/tiddlywiki/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: tiddlywiki
+description: TiddlyWiki5 personal wiki server
+type: application
+version: 0.1.0
+appVersion: "5.4.0"
+
+keywords:
+  - wiki
+  - tiddlywiki
+  - notes
+
+maintainers:
+  - name: TiddlyWiki Community
+    url: https://tiddlywiki.com
+
+dependencies:
+  # OpenTelemetry Collector sidecar (optional, enabled via values.otel.enabled).
+  # Collects Node.js metrics and traces and forwards to your OTEL backend.
+  - name: opentelemetry-collector
+    version: "0.x.x"
+    repository: "https://open-telemetry.github.io/opentelemetry-helm-charts"
+    condition: otel.collector.enabled
+    alias: otelcollector

--- a/helm/tiddlywiki/templates/_helpers.tpl
+++ b/helm/tiddlywiki/templates/_helpers.tpl
@@ -1,0 +1,162 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "tiddlywiki.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "tiddlywiki.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Chart label.
+*/}}
+{{- define "tiddlywiki.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels.
+*/}}
+{{- define "tiddlywiki.labels" -}}
+helm.sh/chart: {{ include "tiddlywiki.chart" . }}
+{{ include "tiddlywiki.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "tiddlywiki.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "tiddlywiki.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Service account name.
+*/}}
+{{- define "tiddlywiki.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "tiddlywiki.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+OTEL sidecar collector ConfigMap name.
+*/}}
+{{- define "tiddlywiki.otelCollectorName" -}}
+{{- printf "%s-otel-collector" (include "tiddlywiki.fullname" .) }}
+{{- end }}
+
+{{/*
+Resolve the OTEL endpoint: user-supplied or default to sidecar localhost.
+*/}}
+{{- define "tiddlywiki.otelEndpoint" -}}
+{{- if .Values.otel.endpoint }}
+{{- .Values.otel.endpoint }}
+{{- else if .Values.otel.sidecar.enabled }}
+{{- if eq .Values.otel.protocol "grpc" }}
+{{- "http://localhost:4317" }}
+{{- else }}
+{{- "http://localhost:4318" }}
+{{- end }}
+{{- else }}
+{{- "http://otel-collector:4317" }}
+{{- end }}
+{{- end }}
+
+{{/*
+The named port the Service targets.
+When oauth2-proxy is enabled the proxy sits in front, so the Service
+port name changes to "proxy". Otherwise it targets "http" on the wiki.
+*/}}
+{{- define "tiddlywiki.serviceTargetPort" -}}
+{{- if .Values.oauth2Proxy.enabled -}}proxy{{- else -}}http{{- end -}}
+{{- end }}
+
+{{/*
+Build the flat list of --listen key=value args for TiddlyWiki.
+Rendered as a YAML string list for use in container args.
+*/}}
+{{- define "tiddlywiki.listenArgs" -}}
+{{- $args := list -}}
+{{- $args = append $args "host=0.0.0.0" -}}
+{{- $args = append $args (printf "port=%d" (int .Values.wiki.port)) -}}
+{{- if .Values.wiki.pathPrefix }}
+{{- $args = append $args (printf "path-prefix=%s" .Values.wiki.pathPrefix) -}}
+{{- end }}
+{{- if .Values.wiki.gzip }}
+{{- $args = append $args "gzip=yes" -}}
+{{- end }}
+{{- if .Values.wiki.browserCache }}
+{{- $args = append $args "use-browser-cache=yes" -}}
+{{- end }}
+{{- if .Values.auth.enabled }}
+{{- if .Values.auth.readers }}
+{{- $args = append $args (printf "readers=%s" .Values.auth.readers) -}}
+{{- end }}
+{{- if .Values.auth.writers }}
+{{- $args = append $args (printf "writers=%s" .Values.auth.writers) -}}
+{{- end }}
+{{- if .Values.auth.admin }}
+{{- $args = append $args (printf "admin=%s" .Values.auth.admin) -}}
+{{- end }}
+{{- if .Values.auth.anonUsername }}
+{{- $args = append $args (printf "anon-username=%s" .Values.auth.anonUsername) -}}
+{{- end }}
+{{- if .Values.auth.credentialsSecret }}
+{{- $args = append $args "credentials=/secrets/credentials.csv" -}}
+{{- else if and .Values.auth.username .Values.auth.password }}
+{{- $args = append $args (printf "username=%s" .Values.auth.username) -}}
+{{- $args = append $args (printf "password=%s" .Values.auth.password) -}}
+{{- end }}
+{{- if .Values.oauth2Proxy.enabled }}
+{{- $args = append $args (printf "authenticated-user-header=%s" .Values.oauth2Proxy.upstreamHeader) -}}
+{{- else if .Values.auth.trustedHeader }}
+{{- $args = append $args (printf "authenticated-user-header=%s" .Values.auth.trustedHeader) -}}
+{{- end }}
+{{- end }}
+{{- range .Values.wiki.extraListenArgs }}
+{{- $args = append $args . -}}
+{{- end }}
+{{- toYaml $args }}
+{{- end }}
+
+{{/*
+oauth2-proxy Secret name.
+*/}}
+{{- define "tiddlywiki.oauth2SecretName" -}}
+{{- .Values.oauth2Proxy.existingSecret | default (printf "%s-oauth2" (include "tiddlywiki.fullname" .)) }}
+{{- end }}
+
+{{/*
+Git sync Secret name.
+*/}}
+{{- define "tiddlywiki.gitSyncSecretName" -}}
+{{- .Values.gitSync.existingSecret | default (printf "%s-git-sync" (include "tiddlywiki.fullname" .)) }}
+{{- end }}
+
+{{/*
+Plugin ConfigMap name for a given plugin entry.
+*/}}
+{{- define "tiddlywiki.pluginConfigMapName" -}}
+{{- printf "%s-plugin-%s" (include "tiddlywiki.fullname" .root) .plugin.name }}
+{{- end }}

--- a/helm/tiddlywiki/templates/configmap-otel.yaml
+++ b/helm/tiddlywiki/templates/configmap-otel.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.otel.enabled .Values.otel.sidecar.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "tiddlywiki.otelCollectorName" . }}-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tiddlywiki.labels" . | nindent 4 }}
+data:
+  collector.yaml: |
+    {{- toYaml .Values.otel.sidecar.config | nindent 4 }}
+{{- end }}

--- a/helm/tiddlywiki/templates/configmap-plugins.yaml
+++ b/helm/tiddlywiki/templates/configmap-plugins.yaml
@@ -1,0 +1,18 @@
+{{- range .Values.plugins }}
+{{- if and (not .existingConfigMap) .data }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "tiddlywiki.fullname" $ }}-plugin-{{ .name }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "tiddlywiki.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: plugin
+data:
+  {{- range $filename, $content := .data }}
+  {{ $filename }}: |
+    {{- $content | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/helm/tiddlywiki/templates/cronjob-git-sync.yaml
+++ b/helm/tiddlywiki/templates/cronjob-git-sync.yaml
@@ -1,0 +1,164 @@
+{{- if .Values.gitSync.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "tiddlywiki.fullname" . }}-git-sync
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tiddlywiki.labels" . | nindent 4 }}
+    app.kubernetes.io/component: git-sync
+spec:
+  schedule: {{ .Values.gitSync.schedule | quote }}
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            {{- include "tiddlywiki.selectorLabels" . | nindent 12 }}
+            app.kubernetes.io/component: git-sync
+        spec:
+          restartPolicy: OnFailure
+
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
+            fsGroup: 65532
+            seccompProfile:
+              type: RuntimeDefault
+
+          initContainers:
+            # Fix ownership of the SSH key mount (git requires 600 perms).
+            - name: fix-ssh-perms
+              image: busybox:1.36-musl
+              command:
+                - sh
+                - -c
+                - |
+                  cp /ssh-ro/id_rsa /ssh/id_rsa
+                  chmod 600 /ssh/id_rsa
+              volumeMounts:
+                - name: ssh-key-ro
+                  mountPath: /ssh-ro
+                  readOnly: true
+                - name: ssh-key-rw
+                  mountPath: /ssh
+              securityContext:
+                runAsNonRoot: false
+                runAsUser: 0
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop: ["ALL"]
+                  add: ["CHOWN", "DAC_OVERRIDE"]
+
+          containers:
+            - name: git-sync
+              image: "{{ .Values.gitSync.image.repository }}:{{ .Values.gitSync.image.tag }}"
+              imagePullPolicy: {{ .Values.gitSync.image.pullPolicy }}
+              command:
+                - sh
+                - -c
+                - |
+                  set -e
+                  WIKI_PATH="{{ .Values.wiki.dataPath }}"
+                  REPO_URL="{{ .Values.gitSync.repoUrl }}"
+                  BRANCH="{{ .Values.gitSync.branch }}"
+
+                  # Configure git identity
+                  git config --global user.name  "{{ .Values.gitSync.authorName }}"
+                  git config --global user.email "{{ .Values.gitSync.authorEmail }}"
+                  git config --global --add safe.directory "$WIKI_PATH"
+
+                  cd "$WIKI_PATH"
+
+                  # Initialise repo if not already a git repo
+                  if [ ! -d .git ]; then
+                    git init -b "$BRANCH"
+                    git remote add origin "$REPO_URL"
+                  fi
+
+                  # Stage all changes
+                  git add -A
+
+                  # Only commit if there are changes
+                  if git diff --cached --quiet; then
+                    echo "No changes to commit."
+                    exit 0
+                  fi
+
+                  TIMESTAMP=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+                  CHANGES=$(git diff --cached --stat | tail -1)
+                  git commit -m "backup: $TIMESTAMP — $CHANGES"
+
+                  # Push (SSH or HTTPS depending on remote URL)
+                  {{- if hasPrefix "git@" .Values.gitSync.repoUrl }}
+                  GIT_SSH_COMMAND="ssh -i /ssh/id_rsa -o StrictHostKeyChecking=no" \
+                    git push origin "$BRANCH"
+                  {{- else }}
+                  git push \
+                    "https://${GIT_USERNAME}:${GIT_PASSWORD}@$(echo "$REPO_URL" | sed 's|https://||')" \
+                    "$BRANCH"
+                  {{- end }}
+
+                  echo "Backup pushed successfully."
+              env:
+                {{- if not (hasPrefix "git@" .Values.gitSync.repoUrl) }}
+                - name: GIT_USERNAME
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "tiddlywiki.gitSyncSecretName" . }}
+                      key: GIT_USERNAME
+                - name: GIT_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "tiddlywiki.gitSyncSecretName" . }}
+                      key: GIT_PASSWORD
+                {{- end }}
+              resources:
+                {{- toYaml .Values.gitSync.resources | nindent 16 }}
+              securityContext:
+                runAsNonRoot: true
+                runAsUser: 65532
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: false  # git needs to write .git/
+                capabilities:
+                  drop: ["ALL"]
+              volumeMounts:
+                - name: wiki-data
+                  mountPath: {{ .Values.wiki.dataPath }}
+                {{- if hasPrefix "git@" .Values.gitSync.repoUrl }}
+                - name: ssh-key-rw
+                  mountPath: /ssh
+                - name: tmp
+                  mountPath: /tmp
+                {{- end }}
+
+          volumes:
+            - name: wiki-data
+              {{- if .Values.persistence.enabled }}
+              persistentVolumeClaim:
+                claimName: {{ if .Values.persistence.existingClaim }}{{ .Values.persistence.existingClaim }}{{ else }}{{ include "tiddlywiki.fullname" . }}-data{{ end }}
+              {{- else }}
+              emptyDir: {}
+              {{- end }}
+            {{- if hasPrefix "git@" .Values.gitSync.repoUrl }}
+            - name: ssh-key-ro
+              secret:
+                secretName: {{ include "tiddlywiki.gitSyncSecretName" . }}
+                items:
+                  - key: {{ .Values.gitSync.sshKeySecretKey }}
+                    path: id_rsa
+            - name: ssh-key-rw
+              emptyDir:
+                medium: Memory
+                sizeLimit: 8Mi
+            - name: tmp
+              emptyDir:
+                medium: Memory
+                sizeLimit: 32Mi
+            {{- end }}
+{{- end }}

--- a/helm/tiddlywiki/templates/cronjob-snapshot.yaml
+++ b/helm/tiddlywiki/templates/cronjob-snapshot.yaml
@@ -1,0 +1,126 @@
+{{- if .Values.volumeSnapshotBackup.enabled }}
+# ServiceAccount with RBAC to create/list/delete VolumeSnapshots.
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "tiddlywiki.fullname" . }}-snapshot-sa
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tiddlywiki.labels" . | nindent 4 }}
+    app.kubernetes.io/component: snapshot-backup
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "tiddlywiki.fullname" . }}-snapshot-role
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tiddlywiki.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["create", "get", "list", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "tiddlywiki.fullname" . }}-snapshot-rolebinding
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tiddlywiki.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "tiddlywiki.fullname" . }}-snapshot-role
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "tiddlywiki.fullname" . }}-snapshot-sa
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "tiddlywiki.fullname" . }}-snapshot
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tiddlywiki.labels" . | nindent 4 }}
+    app.kubernetes.io/component: snapshot-backup
+spec:
+  schedule: {{ .Values.volumeSnapshotBackup.schedule | quote }}
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            {{- include "tiddlywiki.selectorLabels" . | nindent 12 }}
+            app.kubernetes.io/component: snapshot-backup
+        spec:
+          restartPolicy: OnFailure
+          serviceAccountName: {{ include "tiddlywiki.fullname" . }}-snapshot-sa
+
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            seccompProfile:
+              type: RuntimeDefault
+
+          containers:
+            - name: snapshot
+              image: "{{ .Values.volumeSnapshotBackup.image.repository }}:{{ .Values.volumeSnapshotBackup.image.tag }}"
+              imagePullPolicy: {{ .Values.volumeSnapshotBackup.image.pullPolicy }}
+              command:
+                - sh
+                - -c
+                - |
+                  set -e
+                  NAMESPACE="{{ .Release.Namespace }}"
+                  PVC_NAME="{{ if .Values.persistence.existingClaim }}{{ .Values.persistence.existingClaim }}{{ else }}{{ include "tiddlywiki.fullname" . }}-data{{ end }}"
+                  TIMESTAMP=$(date -u '+%Y%m%d%H%M%S')
+                  SNAPSHOT_NAME="{{ include "tiddlywiki.fullname" . }}-${TIMESTAMP}"
+                  RETENTION={{ .Values.volumeSnapshotBackup.retentionCount }}
+
+                  echo "Creating VolumeSnapshot $SNAPSHOT_NAME for PVC $PVC_NAME..."
+
+                  cat <<EOF | kubectl apply -f -
+                  apiVersion: snapshot.storage.k8s.io/v1
+                  kind: VolumeSnapshot
+                  metadata:
+                    name: ${SNAPSHOT_NAME}
+                    namespace: ${NAMESPACE}
+                    labels:
+                      app.kubernetes.io/name: {{ include "tiddlywiki.name" . }}
+                      app.kubernetes.io/instance: {{ .Release.Name }}
+                      backup-type: scheduled
+                  spec:
+                    {{- if .Values.volumeSnapshotBackup.snapshotClass }}
+                    volumeSnapshotClassName: {{ .Values.volumeSnapshotBackup.snapshotClass }}
+                    {{- end }}
+                    source:
+                      persistentVolumeClaimName: ${PVC_NAME}
+                  EOF
+
+                  echo "Snapshot created. Pruning old snapshots (keeping $RETENTION)..."
+
+                  # List snapshots for this wiki, sorted oldest first, delete excess.
+                  kubectl get volumesnapshots -n "$NAMESPACE" \
+                    -l "app.kubernetes.io/instance={{ .Release.Name }},backup-type=scheduled" \
+                    --sort-by=.metadata.creationTimestamp \
+                    -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' \
+                  | head -n "-${RETENTION}" \
+                  | xargs -r kubectl delete volumesnapshot -n "$NAMESPACE"
+
+                  echo "Done."
+              resources:
+                {{- toYaml .Values.volumeSnapshotBackup.resources | nindent 16 }}
+              securityContext:
+                runAsNonRoot: true
+                runAsUser: 65532
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop: ["ALL"]
+{{- end }}

--- a/helm/tiddlywiki/templates/deployment.yaml
+++ b/helm/tiddlywiki/templates/deployment.yaml
@@ -1,0 +1,338 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "tiddlywiki.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tiddlywiki.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "tiddlywiki.selectorLabels" . | nindent 6 }}
+  {{- with .Values.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  template:
+    metadata:
+      labels:
+        {{- include "tiddlywiki.selectorLabels" . | nindent 8 }}
+      annotations:
+        {{- if and .Values.otel.enabled .Values.otel.sidecar.enabled }}
+        checksum/otel-config: {{ include (print $.Template.BasePath "/configmap-otel.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if .Values.plugins }}
+        checksum/plugins: {{ include (print $.Template.BasePath "/configmap-plugins.yaml") . | sha256sum }}
+        {{- end }}
+        prometheus.io/scrape: {{ if and .Values.otel.enabled .Values.otel.sidecar.enabled }}"true"{{ else }}"false"{{ end }}
+        prometheus.io/port: "8888"
+        prometheus.io/path: "/metrics"
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "tiddlywiki.serviceAccountName" . }}
+
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+      # -------------------------------------------------------
+      # Init container: seed /data/wiki with correct ownership.
+      # Distroless has no shell, so busybox does the mkdir/chown.
+      # -------------------------------------------------------
+      initContainers:
+        - name: init-wiki-dir
+          image: busybox:1.36-musl
+          command:
+            - sh
+            - -c
+            - |
+              mkdir -p {{ .Values.wiki.dataPath }}/tiddlers
+              {{- range .Values.plugins }}
+              mkdir -p {{ $.Values.wiki.dataPath }}/plugins/{{ .name }}
+              cp -r /plugins/{{ .name }}/. {{ $.Values.wiki.dataPath }}/plugins/{{ .name }}/
+              {{- end }}
+              chown -R 65532:65532 {{ .Values.wiki.dataPath }}
+          volumeMounts:
+            - name: wiki-data
+              mountPath: {{ .Values.wiki.dataPath }}
+            {{- range .Values.plugins }}
+            - name: plugin-{{ .name }}
+              mountPath: /plugins/{{ .name }}
+              readOnly: true
+            {{- end }}
+          securityContext:
+            runAsNonRoot: false
+            runAsUser: 0
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+              add: ["CHOWN", "DAC_OVERRIDE"]
+
+      containers:
+        # -------------------------------------------------------
+        # Main: TiddlyWiki server
+        # -------------------------------------------------------
+        - name: tiddlywiki
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+
+          # ENTRYPOINT = ["/nodejs/bin/node", "tiddlywiki.js"] (Dockerfile)
+          args:
+            - {{ .Values.wiki.dataPath | quote }}
+            - "--listen"
+            {{- include "tiddlywiki.listenArgs" . | nindent 12 }}
+
+          ports:
+            - name: http
+              containerPort: {{ .Values.wiki.port }}
+              protocol: TCP
+
+          env:
+            - name: NODE_ENV
+              value: "production"
+            - name: TIDDLYWIKI_PLUGIN_PATH
+              value: "{{ .Values.wiki.dataPath }}/plugins"
+            - name: TIDDLYWIKI_THEME_PATH
+              value: "{{ .Values.wiki.dataPath }}/themes"
+            - name: TIDDLYWIKI_LANGUAGE_PATH
+              value: "{{ .Values.wiki.dataPath }}/languages"
+            - name: NODE_OPTIONS
+              value: "--max-old-space-size={{ .Values.nodeHeapMb }}"
+            {{- if .Values.otel.enabled }}
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: {{ include "tiddlywiki.otelEndpoint" . | quote }}
+            - name: OTEL_EXPORTER_OTLP_PROTOCOL
+              value: {{ .Values.otel.protocol | quote }}
+            - name: OTEL_SERVICE_NAME
+              value: {{ .Values.otel.serviceName | quote }}
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: {{ join "," .Values.otel.resourceAttributes | quote }}
+            - name: OTEL_TRACES_EXPORTER
+              value: "otlp"
+            - name: OTEL_METRICS_EXPORTER
+              value: "otlp"
+            - name: OTEL_LOGS_EXPORTER
+              value: "otlp"
+            - name: OTEL_RESOURCE_ATTRIBUTES_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OTEL_RESOURCE_ATTRIBUTES_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+
+          {{- with .Values.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+
+          volumeMounts:
+            - name: wiki-data
+              mountPath: {{ .Values.wiki.dataPath }}
+            - name: tmp
+              mountPath: /tmp
+            {{- if .Values.auth.credentialsSecret }}
+            - name: credentials
+              mountPath: /secrets
+              readOnly: true
+            {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+
+        # -------------------------------------------------------
+        # Sidecar: oauth2-proxy (optional SSO)
+        # Sits in front of TiddlyWiki, handles the OAuth flow,
+        # then forwards requests with X-Auth-Request-User set.
+        # The Service/Ingress targets this port, not TiddlyWiki's.
+        # -------------------------------------------------------
+        {{- if .Values.oauth2Proxy.enabled }}
+        - name: oauth2-proxy
+          image: "{{ .Values.oauth2Proxy.image.repository }}:{{ .Values.oauth2Proxy.image.tag }}"
+          imagePullPolicy: {{ .Values.oauth2Proxy.image.pullPolicy }}
+          args:
+            - "--provider={{ .Values.oauth2Proxy.provider }}"
+            - "--upstream=http://localhost:{{ .Values.wiki.port }}"
+            - "--http-address=0.0.0.0:{{ .Values.oauth2Proxy.port }}"
+            - "--email-domain={{ .Values.oauth2Proxy.emailDomain }}"
+            - "--pass-user-headers=true"
+            - "--set-xauthrequest=true"
+            {{- if .Values.oauth2Proxy.oidcIssuerUrl }}
+            - "--oidc-issuer-url={{ .Values.oauth2Proxy.oidcIssuerUrl }}"
+            {{- end }}
+            {{- if .Values.oauth2Proxy.githubOrg }}
+            - "--github-org={{ .Values.oauth2Proxy.githubOrg }}"
+            {{- end }}
+            {{- if .Values.oauth2Proxy.githubTeam }}
+            - "--github-team={{ .Values.oauth2Proxy.githubTeam }}"
+            {{- end }}
+            {{- range .Values.oauth2Proxy.extraArgs }}
+            - {{ . | quote }}
+            {{- end }}
+          ports:
+            - name: proxy
+              containerPort: {{ .Values.oauth2Proxy.port }}
+              protocol: TCP
+          env:
+            - name: OAUTH2_PROXY_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "tiddlywiki.oauth2SecretName" . }}
+                  key: client-id
+            - name: OAUTH2_PROXY_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "tiddlywiki.oauth2SecretName" . }}
+                  key: client-secret
+            - name: OAUTH2_PROXY_COOKIE_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "tiddlywiki.oauth2SecretName" . }}
+                  key: cookie-secret
+          resources:
+            {{- toYaml .Values.oauth2Proxy.resources | nindent 12 }}
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          livenessProbe:
+            httpGet:
+              path: /ping
+              port: proxy
+            periodSeconds: 30
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /ping
+              port: proxy
+            periodSeconds: 10
+            failureThreshold: 3
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+        {{- end }}
+
+        # -------------------------------------------------------
+        # Sidecar: OTEL Collector (optional)
+        # -------------------------------------------------------
+        {{- if and .Values.otel.enabled .Values.otel.sidecar.enabled }}
+        - name: otel-collector
+          image: "{{ .Values.otel.sidecar.image.repository }}:{{ .Values.otel.sidecar.image.tag }}"
+          imagePullPolicy: {{ .Values.otel.sidecar.image.pullPolicy }}
+          args:
+            - "--config=/conf/collector.yaml"
+          ports:
+            - name: otlp-grpc
+              containerPort: 4317
+              protocol: TCP
+            - name: otlp-http
+              containerPort: 4318
+              protocol: TCP
+            - name: otel-metrics
+              containerPort: 8888
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.otel.sidecar.resources | nindent 12 }}
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: otel-collector-config
+              mountPath: /conf
+            - name: tmp
+              mountPath: /tmp
+        {{- end }}
+
+      # -------------------------------------------------------
+      # Volumes
+      # -------------------------------------------------------
+      volumes:
+        - name: wiki-data
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ if .Values.persistence.existingClaim }}{{ .Values.persistence.existingClaim }}{{ else }}{{ include "tiddlywiki.fullname" . }}-data{{ end }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        - name: tmp
+          emptyDir:
+            medium: Memory
+            sizeLimit: 64Mi
+        {{- if .Values.auth.credentialsSecret }}
+        - name: credentials
+          secret:
+            secretName: {{ .Values.auth.credentialsSecret }}
+            items:
+              - key: credentials.csv
+                path: credentials.csv
+        {{- end }}
+        {{- if and .Values.otel.enabled .Values.otel.sidecar.enabled }}
+        - name: otel-collector-config
+          configMap:
+            name: {{ include "tiddlywiki.otelCollectorName" . }}-config
+        {{- end }}
+        {{- range .Values.plugins }}
+        - name: plugin-{{ .name }}
+          configMap:
+            name: {{ if .existingConfigMap }}{{ .existingConfigMap }}{{ else }}{{ include "tiddlywiki.fullname" $ }}-plugin-{{ .name }}{{ end }}
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+
+      terminationGracePeriodSeconds: 30
+
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm/tiddlywiki/templates/hpa.yaml
+++ b/helm/tiddlywiki/templates/hpa.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.autoscaling.enabled -}}
+# NOTE: HPA only makes sense with a ReadWriteMany PVC (NFS, CephFS, EFS, etc.).
+# With ReadWriteOnce storage, multiple pods cannot attach the same PVC —
+# set persistence.accessMode: ReadWriteMany before enabling this.
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "tiddlywiki.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tiddlywiki.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "tiddlywiki.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/helm/tiddlywiki/templates/ingress.yaml
+++ b/helm/tiddlywiki/templates/ingress.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "tiddlywiki.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tiddlywiki.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- toYaml .Values.ingress.tls | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "tiddlywiki.fullname" $ }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/helm/tiddlywiki/templates/networkpolicy.yaml
+++ b/helm/tiddlywiki/templates/networkpolicy.yaml
@@ -1,0 +1,48 @@
+{{- if .Values.networkPolicy.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "tiddlywiki.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tiddlywiki.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "tiddlywiki.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Allow traffic from the nginx Ingress controller namespace.
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+      ports:
+        - port: {{ .Values.wiki.port }}
+          protocol: TCP
+    {{- if and .Values.otel.enabled .Values.otel.sidecar.enabled }}
+    # Allow OTEL traffic within the pod (sidecar uses localhost; no network policy needed).
+    # If using an external collector, add its namespace/pod selector here.
+    {{- end }}
+  egress:
+    # Allow DNS resolution.
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    # Allow HTTPS for any outbound calls (e.g. OTEL backend).
+    - ports:
+        - port: 443
+          protocol: TCP
+    {{- if and .Values.otel.enabled (not .Values.otel.sidecar.enabled) }}
+    # Allow OTLP to external collector.
+    - ports:
+        - port: 4317
+          protocol: TCP
+        - port: 4318
+          protocol: TCP
+    {{- end }}
+{{- end }}

--- a/helm/tiddlywiki/templates/pdb.yaml
+++ b/helm/tiddlywiki/templates/pdb.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.podDisruptionBudget.enabled -}}
+# PodDisruptionBudget ensures at least minAvailable pods remain during
+# voluntary disruptions (node drains, rolling upgrades).
+# Only meaningful with replicaCount > 1.
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "tiddlywiki.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tiddlywiki.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "tiddlywiki.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/helm/tiddlywiki/templates/pvc.yaml
+++ b/helm/tiddlywiki/templates/pvc.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "tiddlywiki.fullname" . }}-data
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tiddlywiki.labels" . | nindent 4 }}
+  {{- with .Values.persistence.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass }}
+  {{- end }}
+{{- end }}

--- a/helm/tiddlywiki/templates/secret-oauth2.yaml
+++ b/helm/tiddlywiki/templates/secret-oauth2.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.oauth2Proxy.enabled (not .Values.oauth2Proxy.existingSecret) }}
+{{- if or .Values.oauth2Proxy.clientId .Values.oauth2Proxy.clientSecret .Values.oauth2Proxy.cookieSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "tiddlywiki.fullname" . }}-oauth2
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tiddlywiki.labels" . | nindent 4 }}
+  annotations:
+    # Do not store real credentials here in production.
+    # Use existingSecret referencing a Secret managed by External Secrets Operator,
+    # Vault Agent, or Sealed Secrets instead.
+    helm.sh/resource-policy: keep
+type: Opaque
+stringData:
+  client-id: {{ .Values.oauth2Proxy.clientId | quote }}
+  client-secret: {{ .Values.oauth2Proxy.clientSecret | quote }}
+  cookie-secret: {{ .Values.oauth2Proxy.cookieSecret | quote }}
+{{- end }}
+{{- end }}

--- a/helm/tiddlywiki/templates/service.yaml
+++ b/helm/tiddlywiki/templates/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "tiddlywiki.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tiddlywiki.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    {{- include "tiddlywiki.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: {{ include "tiddlywiki.serviceTargetPort" . }}
+      port: {{ .Values.service.port }}
+      targetPort: {{ include "tiddlywiki.serviceTargetPort" . }}
+      protocol: TCP
+  sessionAffinity: None

--- a/helm/tiddlywiki/templates/serviceaccount.yaml
+++ b/helm/tiddlywiki/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "tiddlywiki.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tiddlywiki.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: false
+{{- end }}

--- a/helm/tiddlywiki/templates/servicemonitor.yaml
+++ b/helm/tiddlywiki/templates/servicemonitor.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.serviceMonitor.enabled }}
+# Requires the Prometheus Operator CRD (kube-prometheus-stack or standalone).
+# The ServiceMonitor scrapes the OTEL Collector's /metrics endpoint (port 8888)
+# when otel.sidecar.enabled=true, or the wiki's /status as a synthetic metric
+# when the OTEL sidecar is disabled (limited utility in that case).
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "tiddlywiki.fullname" . }}
+  namespace: {{ .Values.serviceMonitor.namespace | default .Release.Namespace }}
+  labels:
+    {{- include "tiddlywiki.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "tiddlywiki.selectorLabels" . | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  endpoints:
+    {{- if and .Values.otel.enabled .Values.otel.sidecar.enabled }}
+    # Scrape OTEL Collector Prometheus exporter (pushed metrics from the app).
+    - port: otel-metrics
+      path: /metrics
+      interval: {{ .Values.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+    {{- else }}
+    # Scrape /status as a basic up/down health metric.
+    # For richer metrics enable the OTEL sidecar.
+    - port: http
+      path: /status
+      interval: {{ .Values.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+    {{- end }}
+{{- end }}

--- a/helm/tiddlywiki/values-ha.yaml
+++ b/helm/tiddlywiki/values-ha.yaml
@@ -1,0 +1,72 @@
+# High-availability values override.
+# Prerequisites:
+#   - A ReadWriteMany storage class (NFS, CephFS, AWS EFS, etc.)
+#   - Enough cluster nodes for pod anti-affinity to spread replicas
+#
+# Usage:
+#   helm upgrade --install tiddlywiki ./helm/tiddlywiki \
+#     -f helm/tiddlywiki/values-ha.yaml \
+#     --set image.tag=v5.4.0
+
+replicaCount: 2
+
+# Must be RWX for multiple pods to attach the same PVC simultaneously.
+persistence:
+  accessMode: ReadWriteMany
+  storageClass: nfs-client    # Replace with your RWX storage class
+  size: 10Gi
+
+# Recreate is wrong for HA — use RollingUpdate so one pod is always serving.
+strategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxUnavailable: 0
+    maxSurge: 1
+
+resources:
+  requests:
+    memory: 256Mi
+    cpu: 200m
+  limits:
+    memory: 512Mi
+    cpu: 1000m
+
+nodeHeapMb: 384
+
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 4
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 80
+
+# Spread replicas across zones for zone HA.
+affinity:
+  podAntiAffinity:
+    # Hard anti-affinity: never two pods on the same node.
+    requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+            - key: app.kubernetes.io/name
+              operator: In
+              values:
+                - tiddlywiki
+        topologyKey: kubernetes.io/hostname
+    # Prefer spreading across availability zones.
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+              - key: app.kubernetes.io/name
+                operator: In
+                values:
+                  - tiddlywiki
+          topologyKey: topology.kubernetes.io/zone
+
+networkPolicy:
+  enabled: true

--- a/helm/tiddlywiki/values-otel.yaml
+++ b/helm/tiddlywiki/values-otel.yaml
@@ -1,0 +1,119 @@
+# OpenTelemetry observability values override.
+# Enables a sidecar OTEL Collector that receives OTLP from the app
+# and forwards to your backend (Grafana Cloud, Jaeger, Tempo, etc.)
+#
+# Usage:
+#   helm upgrade --install tiddlywiki ./helm/tiddlywiki \
+#     -f helm/tiddlywiki/values-otel.yaml
+#
+# To add Node.js OTEL auto-instrumentation to the image, install the SDK:
+#   npm install --save @opentelemetry/api \
+#     @opentelemetry/auto-instrumentations-node \
+#     @opentelemetry/exporter-trace-otlp-grpc \
+#     @opentelemetry/exporter-metrics-otlp-grpc
+# Then set NODE_OPTIONS below to --require the initialiser.
+# See: https://opentelemetry.io/docs/languages/js/getting-started/nodejs/
+
+otel:
+  enabled: true
+  protocol: grpc
+  serviceName: tiddlywiki
+
+  resourceAttributes:
+    - "deployment.environment=production"
+    - "service.version=5.4.0"
+
+  sidecar:
+    enabled: true
+    image:
+      repository: otel/opentelemetry-collector-contrib
+      tag: "0.98.0"
+    resources:
+      requests:
+        memory: 64Mi
+        cpu: 50m
+      limits:
+        memory: 128Mi
+        cpu: 200m
+
+    # Customise the collector pipeline to match your backend.
+    config:
+      receivers:
+        otlp:
+          protocols:
+            grpc:
+              endpoint: 0.0.0.0:4317
+            http:
+              endpoint: 0.0.0.0:4318
+        # Scrape Node.js process metrics exposed by the OTEL SDK.
+        prometheus:
+          config:
+            scrape_configs:
+              - job_name: tiddlywiki
+                scrape_interval: 15s
+                static_configs:
+                  - targets: ["localhost:9464"]
+
+      processors:
+        batch:
+          timeout: 5s
+          send_batch_size: 1024
+        memory_limiter:
+          check_interval: 1s
+          limit_mib: 100
+        # Add k8s metadata to all telemetry.
+        k8sattributes:
+          auth_type: serviceAccount
+          passthrough: false
+          extract:
+            metadata:
+              - k8s.pod.name
+              - k8s.pod.uid
+              - k8s.deployment.name
+              - k8s.namespace.name
+              - k8s.node.name
+              - k8s.pod.start_time
+
+      exporters:
+        # --------------------------------------------------------
+        # Replace with your actual backend.
+        # Examples:
+        #
+        # Grafana Cloud OTLP:
+        #   otlp:
+        #     endpoint: https://otlp-gateway-prod-eu-west-0.grafana.net/otlp
+        #     headers:
+        #       authorization: Basic <base64(instanceId:apiKey)>
+        #
+        # Local Jaeger (all-in-one):
+        #   otlp:
+        #     endpoint: http://jaeger:4317
+        #     tls:
+        #       insecure: true
+        #
+        # Prometheus remote write:
+        #   prometheusremotewrite:
+        #     endpoint: http://prometheus:9090/api/v1/write
+        # --------------------------------------------------------
+        debug:
+          verbosity: detailed   # Change to 'basic' or remove in prod
+
+      service:
+        pipelines:
+          traces:
+            receivers: [otlp]
+            processors: [memory_limiter, k8sattributes, batch]
+            exporters: [debug]
+          metrics:
+            receivers: [otlp, prometheus]
+            processors: [memory_limiter, k8sattributes, batch]
+            exporters: [debug]
+          logs:
+            receivers: [otlp]
+            processors: [memory_limiter, batch]
+            exporters: [debug]
+
+# If you've added OTEL SDK instrumentation to the image, enable it here:
+# extraEnv:
+#   - name: NODE_OPTIONS
+#     value: "--require /app/otel-init.js --max-old-space-size=192"

--- a/helm/tiddlywiki/values.yaml
+++ b/helm/tiddlywiki/values.yaml
@@ -1,0 +1,455 @@
+# Default values for tiddlywiki Helm chart.
+# Override with: helm install tiddlywiki ./helm/tiddlywiki -f my-values.yaml
+
+# -- Container image settings
+image:
+  repository: ghcr.io/mibmal/tiddlywiki5
+  tag: "latest"
+  pullPolicy: IfNotPresent
+  pullSecrets: []
+
+# -- Number of replicas.
+# NOTE: TiddlyWiki writes tiddlers directly to disk with no distributed
+# locking. With replicaCount > 1 you MUST use a ReadWriteMany storage
+# class (NFS, CephFS, AWS EFS, etc.). See values-ha.yaml.
+replicaCount: 1
+
+# =============================================================================
+# TiddlyWiki server configuration
+# =============================================================================
+wiki:
+  # -- Path inside the container to serve.
+  # /app/editions/server = bundled demo (no PVC needed, resets on upgrade).
+  # /data/wiki           = persistent user wiki (requires PVC).
+  dataPath: /data/wiki
+
+  # -- Server port (container-internal)
+  port: 8080
+
+  # -- URL path prefix if hosting under a sub-path (e.g. "/wiki")
+  pathPrefix: ""
+
+  # -- Enable gzip compression of responses
+  gzip: true
+
+  # -- Enable ETags / browser caching (reduces bandwidth on re-visits)
+  browserCache: true
+
+  # -- Extra --listen key=value args appended verbatim
+  extraListenArgs: []
+  # - "debug-level=none"
+  # - "root-tiddler=$:/core/save/all"
+
+# =============================================================================
+# Authentication & Authorization
+# =============================================================================
+auth:
+  # -- Enable authentication. When false, the wiki is fully public (no login).
+  enabled: false
+
+  # -- Single built-in user. Ignored when credentialsSecret is set.
+  username: ""
+  password: ""
+
+  # -- Reference a pre-existing Secret containing a credentials CSV file.
+  # The Secret must have a key named "credentials.csv" with columns
+  # "username" and "password" (plaintext — use oauth2-proxy for real SSO).
+  # Create it with:
+  #   kubectl create secret generic wiki-credentials \
+  #     --from-file=credentials.csv=./credentials.csv
+  credentialsSecret: ""
+
+  # -- Comma-separated list of users (or "(anon)", "(authenticated)") allowed to read.
+  readers: "(authenticated)"
+
+  # -- Comma-separated list of users allowed to write.
+  writers: "(authenticated)"
+
+  # -- Comma-separated admin users (optional).
+  admin: ""
+
+  # -- Username shown for anonymous visitors.
+  anonUsername: "anonymous"
+
+  # -- If oauth2-proxy (or another trusted reverse proxy) is in use, TiddlyWiki
+  # will read the authenticated username from this header instead of Basic Auth.
+  # oauth2-proxy emits "X-Auth-Request-User" by default.
+  # Set this when oauth2Proxy.enabled = true (done automatically).
+  trustedHeader: ""
+
+# =============================================================================
+# oauth2-proxy sidecar (SSO via Google, GitHub, Okta, any OIDC provider)
+# =============================================================================
+# Flow: browser → oauth2-proxy (port 4180) → TiddlyWiki (port 8080)
+# oauth2-proxy handles the OAuth dance, then forwards requests with
+# X-Auth-Request-User set to the authenticated user's email/login.
+# TiddlyWiki reads that header and treats the user as authenticated.
+# The Service and Ingress point at port 4180, not 8080.
+oauth2Proxy:
+  enabled: false
+
+  image:
+    repository: quay.io/oauth2-proxy/oauth2-proxy
+    tag: "v7.6.0"
+    pullPolicy: IfNotPresent
+
+  # -- OAuth provider: google, github, oidc, gitlab, azure, etc.
+  provider: github
+
+  # -- Client credentials — reference a Secret rather than putting them in values.
+  # Create with:
+  #   kubectl create secret generic wiki-oauth2 \
+  #     --from-literal=client-id=YOUR_ID \
+  #     --from-literal=client-secret=YOUR_SECRET \
+  #     --from-literal=cookie-secret=$(openssl rand -base64 32)
+  existingSecret: ""
+
+  # -- Inline credentials (less secure — prefer existingSecret in prod)
+  clientId: ""
+  clientSecret: ""
+  # -- Cookie encryption key. Generate: openssl rand -base64 32
+  cookieSecret: ""
+
+  # -- OIDC issuer URL (required when provider=oidc)
+  oidcIssuerUrl: ""
+
+  # -- Restrict login to users from this email domain (e.g. "example.com").
+  # Leave empty to allow any authenticated user.
+  emailDomain: "*"
+
+  # -- GitHub org/team restriction (provider=github only)
+  githubOrg: ""
+  githubTeam: ""
+
+  # -- Header oauth2-proxy sets on forwarded requests.
+  # Must match auth.trustedHeader in TiddlyWiki config.
+  upstreamHeader: "X-Auth-Request-User"
+
+  # -- Port oauth2-proxy listens on (becomes the Service/Ingress target port).
+  port: 4180
+
+  # -- Extra args passed to oauth2-proxy
+  extraArgs: []
+  # - "--cookie-secure=true"
+  # - "--cookie-samesite=lax"
+  # - "--reverse-proxy=true"
+
+  resources:
+    requests:
+      memory: 32Mi
+      cpu: 20m
+    limits:
+      memory: 64Mi
+      cpu: 100m
+
+# =============================================================================
+# Plugin injection via ConfigMap
+# =============================================================================
+# Mount custom TiddlyWiki plugins from a ConfigMap without rebuilding the image.
+# Each entry creates a ConfigMap (from inline data) and mounts it under
+# TIDDLYWIKI_PLUGIN_PATH so TiddlyWiki discovers it at startup.
+#
+# Alternatively, set existingConfigMap to reference a pre-created ConfigMap.
+#
+# Example — a minimal custom plugin:
+# plugins:
+#   - name: my-banner
+#     existingConfigMap: my-banner-plugin   # pre-created ConfigMap
+#   - name: dark-toolbar
+#     data:
+#       plugin.info: |
+#         {"title":"$:/plugins/custom/dark-toolbar","name":"Dark Toolbar","description":"Dark toolbar theme fix"}
+#       dark-toolbar.tid: |
+#         title: $:/plugins/custom/dark-toolbar/styles
+#         tags: $:/tags/Stylesheet
+#         .tc-topbar { background: #1a1a2e; }
+plugins: []
+
+# =============================================================================
+# Git sync backup CronJob
+# =============================================================================
+# Commits and pushes /data/wiki to a git remote on a schedule.
+# Gives you a full audit trail and off-site backup with no extra infra.
+# Requires a Secret with a deploy key or HTTPS token.
+gitSync:
+  enabled: false
+
+  # -- Cron schedule (default: every hour)
+  schedule: "0 * * * *"
+
+  # -- Git remote URL (SSH or HTTPS)
+  # SSH:   git@github.com:youruser/wiki-backup.git
+  # HTTPS: https://github.com/youruser/wiki-backup.git
+  repoUrl: ""
+
+  # -- Git branch to push to
+  branch: main
+
+  # -- Commit author identity
+  authorName: "TiddlyWiki Backup"
+  authorEmail: "backup@tiddlywiki.local"
+
+  # -- Secret containing SSH key or HTTPS credentials.
+  # For SSH:   kubectl create secret generic wiki-git-ssh --from-file=id_rsa=./deploy_key
+  # For HTTPS: kubectl create secret generic wiki-git-https \
+  #              --from-literal=GIT_USERNAME=youruser \
+  #              --from-literal=GIT_PASSWORD=ghp_token
+  existingSecret: ""
+
+  # -- Secret key holding the SSH private key (for SSH remotes)
+  sshKeySecretKey: "id_rsa"
+
+  image:
+    repository: alpine/git
+    tag: "2.43.0"
+    pullPolicy: IfNotPresent
+
+  resources:
+    requests:
+      memory: 32Mi
+      cpu: 20m
+    limits:
+      memory: 64Mi
+      cpu: 100m
+
+# =============================================================================
+# VolumeSnapshot backup CronJob
+# =============================================================================
+# Creates a CSI VolumeSnapshot of the wiki PVC on a schedule.
+# Requires a CSI driver that supports VolumeSnapshots (most cloud providers do).
+volumeSnapshotBackup:
+  enabled: false
+
+  # -- Cron schedule (default: 2am daily)
+  schedule: "0 2 * * *"
+
+  # -- VolumeSnapshotClass to use. Leave empty for the cluster default.
+  snapshotClass: ""
+
+  # -- How many snapshots to keep (older ones are deleted)
+  retentionCount: 7
+
+  image:
+    repository: bitnami/kubectl
+    tag: "latest"
+    pullPolicy: IfNotPresent
+
+  resources:
+    requests:
+      memory: 32Mi
+      cpu: 20m
+    limits:
+      memory: 64Mi
+      cpu: 100m
+
+# =============================================================================
+# Kubernetes Service
+# =============================================================================
+service:
+  type: ClusterIP
+  # -- Exposed port. When oauth2Proxy.enabled, traffic enters via proxy port.
+  port: 80
+
+# =============================================================================
+# Ingress
+# =============================================================================
+ingress:
+  enabled: false
+  className: nginx
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/proxy-body-size: "50m"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "60"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      add_header X-Frame-Options "SAMEORIGIN" always;
+      add_header X-Content-Type-Options "nosniff" always;
+      add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    # cert-manager.io/cluster-issuer: letsencrypt-prod
+  hosts:
+    - host: wiki.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+  # - secretName: tiddlywiki-tls
+  #   hosts:
+  #     - wiki.example.com
+
+# =============================================================================
+# Persistent storage for wiki data
+# =============================================================================
+persistence:
+  enabled: true
+  existingClaim: ""
+  storageClass: ""
+  accessMode: ReadWriteOnce
+  size: 1Gi
+  annotations:
+    helm.sh/resource-policy: keep
+
+# =============================================================================
+# Resources, scaling, security
+# =============================================================================
+resources:
+  requests:
+    memory: 128Mi
+    cpu: 100m
+  limits:
+    memory: 256Mi
+    cpu: 500m
+
+# -- Node.js V8 heap cap (MiB). Keep at ~75% of memory limit.
+nodeHeapMb: 192
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 65532
+  runAsGroup: 65532
+  fsGroup: 65532
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop: ["ALL"]
+  seccompProfile:
+    type: RuntimeDefault
+
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 1
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 3
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 80
+
+# =============================================================================
+# Probes — using /status (JSON, cheap) instead of / (full HTML render)
+# =============================================================================
+startupProbe:
+  httpGet:
+    path: /status
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 5
+  failureThreshold: 6
+
+livenessProbe:
+  httpGet:
+    path: /status
+    port: http
+  periodSeconds: 30
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /status
+    port: http
+  periodSeconds: 10
+  timeoutSeconds: 3
+  failureThreshold: 3
+
+# =============================================================================
+# Scheduling
+# =============================================================================
+nodeSelector: {}
+tolerations: []
+affinity:
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+              - key: app.kubernetes.io/name
+                operator: In
+                values:
+                  - tiddlywiki
+          topologyKey: kubernetes.io/hostname
+
+# =============================================================================
+# Misc
+# =============================================================================
+extraEnv: []
+extraVolumes: []
+extraVolumeMounts: []
+
+strategy:
+  type: Recreate
+
+podAnnotations: {}
+
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+
+networkPolicy:
+  enabled: false
+
+# -- Prometheus Operator ServiceMonitor
+serviceMonitor:
+  enabled: false
+  # -- Namespace where the Prometheus Operator is running (if different)
+  namespace: ""
+  interval: 30s
+  scrapeTimeout: 10s
+  labels: {}
+
+# =============================================================================
+# OpenTelemetry Metrics & Tracing
+# =============================================================================
+otel:
+  enabled: false
+  endpoint: ""
+  protocol: grpc
+  serviceName: tiddlywiki
+  resourceAttributes: []
+  # - "deployment.environment=production"
+
+  sidecar:
+    enabled: false
+    image:
+      repository: otel/opentelemetry-collector-contrib
+      tag: "0.98.0"
+      pullPolicy: IfNotPresent
+    resources:
+      requests:
+        memory: 64Mi
+        cpu: 50m
+      limits:
+        memory: 128Mi
+        cpu: 200m
+    config:
+      receivers:
+        otlp:
+          protocols:
+            grpc:
+              endpoint: 0.0.0.0:4317
+            http:
+              endpoint: 0.0.0.0:4318
+      processors:
+        batch:
+          timeout: 5s
+        memory_limiter:
+          check_interval: 1s
+          limit_mib: 100
+      exporters:
+        debug:
+          verbosity: basic
+      service:
+        pipelines:
+          traces:
+            receivers: [otlp]
+            processors: [memory_limiter, batch]
+            exporters: [debug]
+          metrics:
+            receivers: [otlp]
+            processors: [memory_limiter, batch]
+            exporters: [debug]

--- a/k8s/base/deployment.yaml
+++ b/k8s/base/deployment.yaml
@@ -1,0 +1,211 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tiddlywiki
+  labels:
+    app.kubernetes.io/name: tiddlywiki
+    app.kubernetes.io/component: wiki
+  annotations:
+    app.kubernetes.io/description: "TiddlyWiki5 personal wiki server"
+spec:
+  # TiddlyWiki's filesystem adaptor writes directly to disk with no
+  # distributed locking. Multiple replicas sharing a ReadWriteOnce PVC
+  # would corrupt tiddler files. Keep at 1; see HA notes in README.
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: tiddlywiki
+      app.kubernetes.io/component: wiki
+  strategy:
+    # Recreate avoids two pods attaching the same RWO PVC simultaneously,
+    # which most storage classes reject outright (Multi-Attach error).
+    # This causes a brief downtime during deploys — acceptable for a wiki.
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: tiddlywiki
+        app.kubernetes.io/component: wiki
+      annotations:
+        # Prometheus scrape annotations — override once a metrics endpoint exists.
+        prometheus.io/scrape: "false"
+        prometheus.io/port: "9464"
+        prometheus.io/path: "/metrics"
+    spec:
+      # -------------------------------------------------------
+      # Pod-level security context
+      # -------------------------------------------------------
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532      # distroless 'nonroot' uid
+        runAsGroup: 65532     # distroless 'nonroot' gid
+        fsGroup: 65532        # PVC files owned by nonroot on mount
+        seccompProfile:
+          type: RuntimeDefault
+
+      # -------------------------------------------------------
+      # Init container: seed /data/wiki directory structure.
+      # Required because:
+      #   (a) distroless has no shell to run mkdir
+      #   (b) an empty PVC mounts as root:root by default
+      #   (c) fsGroup handles ongoing ownership but the tiddlers/
+      #       subdir must exist before the filesystem adaptor starts
+      # -------------------------------------------------------
+      initContainers:
+        - name: init-wiki-dir
+          image: busybox:1.36-musl
+          command:
+            - sh
+            - -c
+            - |
+              mkdir -p /data/wiki/tiddlers
+              chown -R 65532:65532 /data/wiki
+          volumeMounts:
+            - name: wiki-data
+              mountPath: /data/wiki
+          securityContext:
+            runAsNonRoot: false
+            runAsUser: 0
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+              add: ["CHOWN", "DAC_OVERRIDE"]
+
+      containers:
+        - name: tiddlywiki
+          # Image name is overridden by the kustomization images stanza.
+          image: tiddlywiki:latest
+          imagePullPolicy: IfNotPresent
+
+          # Args override the image's default CMD.
+          # ENTRYPOINT is ["/nodejs/bin/node", "tiddlywiki.js"] (from Dockerfile).
+          # Serving from the PVC-mounted wiki:
+          args:
+            - "/data/wiki"
+            - "--listen"
+            - "host=0.0.0.0"
+            - "port=8080"
+          # To serve the bundled demo edition instead, set args to:
+          # args: ["/app/editions/server", "--listen", "host=0.0.0.0", "port=8080"]
+
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+
+          # -------------------------------------------------------
+          # Environment variables
+          # -------------------------------------------------------
+          env:
+            - name: NODE_ENV
+              value: "production"
+            # TiddlyWiki reads these to extend plugin/theme search paths,
+            # enabling plugin injection from the PVC without rebuilding the image.
+            - name: TIDDLYWIKI_PLUGIN_PATH
+              value: "/data/wiki/plugins"
+            - name: TIDDLYWIKI_THEME_PATH
+              value: "/data/wiki/themes"
+            - name: TIDDLYWIKI_LANGUAGE_PATH
+              value: "/data/wiki/languages"
+            # Cap the Node.js V8 heap to stay within container memory limits.
+            - name: NODE_OPTIONS
+              value: "--max-old-space-size=192"
+
+          # -------------------------------------------------------
+          # Resource management
+          # -------------------------------------------------------
+          resources:
+            requests:
+              # TiddlyWiki is lightweight; Node baseline is ~50-80Mi RSS.
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              # Raise in prod overlay for large wikis.
+              memory: "256Mi"
+              cpu: "500m"
+
+          # -------------------------------------------------------
+          # Probes
+          # -------------------------------------------------------
+          # /status returns JSON {tiddlywiki_version, username, anonymous, ...}
+          # and is cheaper than / (no full HTML render).
+          startupProbe:
+            httpGet:
+              path: /status
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 6
+            successThreshold: 1
+
+          livenessProbe:
+            httpGet:
+              path: /status
+              port: http
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+            successThreshold: 1
+
+          readinessProbe:
+            httpGet:
+              path: /status
+              port: http
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+            successThreshold: 1
+
+          # -------------------------------------------------------
+          # Container security context
+          # -------------------------------------------------------
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
+            allowPrivilegeEscalation: false
+            # /app (source) is read-only — good. /data/wiki is a volume
+            # mount and remains writable even with readOnlyRootFilesystem.
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
+
+          # -------------------------------------------------------
+          # Volume mounts
+          # -------------------------------------------------------
+          volumeMounts:
+            - name: wiki-data
+              mountPath: /data/wiki
+            # /tmp emptyDir as a defensive measure for Node.js internals;
+            # TiddlyWiki itself does not write to /tmp.
+            - name: tmp
+              mountPath: /tmp
+
+      # -------------------------------------------------------
+      # Volumes
+      # -------------------------------------------------------
+      volumes:
+        - name: wiki-data
+          persistentVolumeClaim:
+            claimName: tiddlywiki-data
+        - name: tmp
+          emptyDir:
+            medium: Memory
+            sizeLimit: 64Mi
+
+      # Give TiddlyWiki time to finish in-flight writes before SIGKILL.
+      terminationGracePeriodSeconds: 30
+
+      # Discourage co-location with other wiki instances (edge case with HPA).
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: tiddlywiki
+                topologyKey: kubernetes.io/hostname

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -1,0 +1,23 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: tiddlywiki
+
+resources:
+  - namespace.yaml
+  - pvc.yaml
+  - deployment.yaml
+  - service.yaml
+
+# Image published to Docker Hub via GitHub Actions on every master push.
+# Pin to a digest in prod overlay for reproducibility.
+# Install: helm repo add mibmal https://mibmal.github.io/TiddlyWiki5
+images:
+  - name: tiddlywiki
+    newName: mibmal/tiddlywiki
+    newTag: latest
+
+commonLabels:
+  app.kubernetes.io/name: tiddlywiki
+  app.kubernetes.io/component: wiki
+  app.kubernetes.io/managed-by: kustomize

--- a/k8s/base/namespace.yaml
+++ b/k8s/base/namespace.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tiddlywiki
+  labels:
+    app.kubernetes.io/name: tiddlywiki
+    # Pod Security Standards (Kubernetes 1.23+): enforce the restricted profile.
+    # This requires all pods to use non-root, no privilege escalation,
+    # dropped capabilities, and seccompProfile RuntimeDefault.
+    # The Deployment security context below satisfies all constraints.
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: latest
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: latest

--- a/k8s/base/pvc.yaml
+++ b/k8s/base/pvc.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: tiddlywiki-data
+  labels:
+    app.kubernetes.io/name: tiddlywiki
+    app.kubernetes.io/component: wiki
+  annotations:
+    # Prevent accidental deletion via Kustomize pruning.
+    # Also schedule VolumeSnapshots for backup in production.
+    helm.sh/resource-policy: keep
+spec:
+  accessModes:
+    # ReadWriteOnce is correct for the single-pod deployment model.
+    # If you move to HA with a shared filesystem, use ReadWriteMany
+    # with an NFS or CephFS storage class.
+    - ReadWriteOnce
+  resources:
+    requests:
+      # 1Gi handles thousands of tiddlers (~1-5KB each as .tid text files).
+      # Resize in overlays as content grows.
+      storage: 1Gi
+  # storageClassName omitted to use the cluster default.
+  # Pin in overlays: storageClassName: standard-retain

--- a/k8s/base/service.yaml
+++ b/k8s/base/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: tiddlywiki
+  labels:
+    app.kubernetes.io/name: tiddlywiki
+    app.kubernetes.io/component: wiki
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: tiddlywiki
+    app.kubernetes.io/component: wiki
+  ports:
+    - name: http
+      port: 80
+      targetPort: http    # resolves to named port 8080 on the container
+      protocol: TCP
+  sessionAffinity: None

--- a/k8s/overlays/dev/kustomization.yaml
+++ b/k8s/overlays/dev/kustomization.yaml
@@ -1,0 +1,80 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: tiddlywiki
+
+resources:
+  - ../../base
+
+# Build locally: docker build -t mibmal/tiddlywiki:dev .
+# Load into kind:      kind load docker-image mibmal/tiddlywiki:dev
+# Load into minikube:  minikube image load mibmal/tiddlywiki:dev
+# Or pull from DockerHub: docker pull mibmal/tiddlywiki:latest
+images:
+  - name: tiddlywiki
+    newName: mibmal/tiddlywiki
+    newTag: dev
+
+commonLabels:
+  environment: dev
+
+patches:
+  # Reduce resource requests/limits for dev clusters (kind, minikube, Docker Desktop).
+  - target:
+      kind: Deployment
+      name: tiddlywiki
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/resources
+        value:
+          requests:
+            memory: "64Mi"
+            cpu: "50m"
+          limits:
+            memory: "128Mi"
+            cpu: "250m"
+
+  # Relax startup budget on slow dev machines.
+  - target:
+      kind: Deployment
+      name: tiddlywiki
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/startupProbe/failureThreshold
+        value: 12
+      - op: replace
+        path: /spec/template/spec/containers/0/livenessProbe/periodSeconds
+        value: 60
+
+  # NodePort for direct browser access without an Ingress controller.
+  # Access at: http://localhost:30080 (kind) or http://$(minikube ip):30080
+  - target:
+      kind: Service
+      name: tiddlywiki
+    patch: |-
+      - op: replace
+        path: /spec/type
+        value: NodePort
+      - op: add
+        path: /spec/ports/0/nodePort
+        value: 30080
+
+  # Smaller PVC for dev storage.
+  - target:
+      kind: PersistentVolumeClaim
+      name: tiddlywiki-data
+    patch: |-
+      - op: replace
+        path: /spec/resources/requests/storage
+        value: 256Mi
+
+  # Remove PSS enforce labels so dev namespace doesn't block experimentation.
+  # Warn/audit labels are kept to surface any policy violations.
+  - target:
+      kind: Namespace
+      name: tiddlywiki
+    patch: |-
+      - op: remove
+        path: /metadata/labels/pod-security.kubernetes.io~1enforce
+      - op: remove
+        path: /metadata/labels/pod-security.kubernetes.io~1enforce-version

--- a/k8s/overlays/prod/ingress.yaml
+++ b/k8s/overlays/prod/ingress.yaml
@@ -1,0 +1,52 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: tiddlywiki
+  labels:
+    app.kubernetes.io/name: tiddlywiki
+    app.kubernetes.io/component: wiki
+    environment: prod
+  annotations:
+    # Force HTTPS — redirect HTTP → HTTPS with 308.
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+
+    # Allow large tiddler imports (PUT /recipes/default/tiddlers/:title).
+    nginx.ingress.kubernetes.io/proxy-body-size: "50m"
+
+    # Timeouts for wiki page rendering (synchronous, may be slow on large wikis).
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: "10"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "60"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "60"
+
+    # cert-manager: automatically provision a Let's Encrypt TLS certificate.
+    # Prerequisite: install cert-manager and create a ClusterIssuer named
+    # 'letsencrypt-prod' before applying this overlay.
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+
+    # Security response headers injected by nginx.
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      add_header X-Frame-Options "SAMEORIGIN" always;
+      add_header X-Content-Type-Options "nosniff" always;
+      add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+      add_header Permissions-Policy "geolocation=(), microphone=(), camera=()" always;
+
+spec:
+  ingressClassName: nginx    # Adjust to your cluster's IngressClass name.
+
+  tls:
+    - hosts:
+        - wiki.example.com    # Replace with your domain.
+      secretName: tiddlywiki-tls
+
+  rules:
+    - host: wiki.example.com  # Replace with your domain.
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: tiddlywiki
+                port:
+                  name: http

--- a/k8s/overlays/prod/kustomization.yaml
+++ b/k8s/overlays/prod/kustomization.yaml
@@ -1,0 +1,68 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: tiddlywiki
+
+resources:
+  - ../../base
+  - ingress.yaml
+
+# Production image from Docker Hub. Pin to a digest for reproducibility:
+#   docker pull mibmal/tiddlywiki:v5.4.0
+#   docker inspect --format='{{index .RepoDigests 0}}' mibmal/tiddlywiki:v5.4.0
+# Then replace newTag with: "@sha256:abc123..."
+images:
+  - name: tiddlywiki
+    newName: mibmal/tiddlywiki
+    newTag: v5.4.0
+
+commonLabels:
+  environment: prod
+
+patches:
+  # Increase resources for production traffic and large wikis.
+  - target:
+      kind: Deployment
+      name: tiddlywiki
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/resources
+        value:
+          requests:
+            memory: "256Mi"
+            cpu: "200m"
+          limits:
+            memory: "512Mi"
+            cpu: "1000m"
+
+  # Always pull to validate the pinned digest against the registry.
+  - target:
+      kind: Deployment
+      name: tiddlywiki
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/imagePullPolicy
+        value: Always
+
+  # Larger heap for production wikis with many tiddlers.
+  - target:
+      kind: Deployment
+      name: tiddlywiki
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/env/3/value
+        value: "--max-old-space-size=448"
+
+  # Larger PVC with a 'Retain' reclaim policy storage class.
+  # Create a StorageClass named 'standard-retain' with reclaimPolicy: Retain
+  # so the volume survives accidental PVC deletion.
+  - target:
+      kind: PersistentVolumeClaim
+      name: tiddlywiki-data
+    patch: |-
+      - op: replace
+        path: /spec/resources/requests/storage
+        value: 10Gi
+      - op: add
+        path: /spec/storageClassName
+        value: standard-retain


### PR DESCRIPTION
Consolidates the deployment work onto master (additive, no conflicts with upstream-synced code) and makes the fork self-maintaining.

- **helm/tiddlywiki/** chart + **k8s/** kustomize + DOCKER.md (from the old feature/k8s-helm-otel branch)
- **ghcr-publish.yml** — builds the Dockerfile `run` stage → `ghcr.io/mibmal/tiddlywiki5` (GITHUB_TOKEN, no DockerHub secrets)
- **helm-publish.yml** — chart-releaser → gh-pages + OCI push to GHCR (DockerHub removed); chart image → `ghcr.io/mibmal/tiddlywiki5`
- **upstream-sync.yml** — weekly merge from `TiddlyWiki/TiddlyWiki5`, opens a PR only on conflict, so the fork tracks upstream without manual work
- all actions SHA-pinned

After merge the feature/dockerfile and feature/k8s-helm-otel branches can be deleted (their content is here or already on master).