### PR TITLE
fix(helm): set explicit command so chart doesn't crash-loop on dumb-init entrypoint

### DIFF
--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -15,7 +15,84 @@ permissions:
   packages: write
 
 jobs:
+  # ---------------------------------------------------------------------------
+  # Smoke test: build the run stage and start it the way the Helm chart does
+  # (explicit command + args, data dir mounted as a volume), then confirm
+  # /status answers. Guards against two regressions that crash-looped before:
+  #   1. The image ENTRYPOINT is dumb-init and the "node ./tiddlywiki.js" prefix
+  #      lives only in CMD; Kubernetes args replace CMD, so a chart without an
+  #      explicit command ran `dumb-init -- /data/wiki ...` and tried to exec
+  #      the data directory -> "[dumb-init] /data/wiki: Permission denied".
+  #   2. A fresh PVC (non-empty: contains lost+found) was not seeded, so the
+  #      server booted without the filesystem/tiddlyweb plugins and silently
+  #      dropped writes.
+  # The publish job depends on this passing.
+  # ---------------------------------------------------------------------------
+  smoke-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
+      - name: Build run stage (loaded locally)
+        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
+        with:
+          context: .
+          target: run
+          load: true
+          tags: tiddlywiki5:smoke
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Simulate a freshly provisioned ext4 PVC
+        run: |
+          # A real ext4 PVC is non-empty on first mount: it has lost+found.
+          mkdir -p "$PWD/pvc/lost+found"
+          # Reproduce the Deployment's initContainers: chown to the runtime user
+          # (1000 = node in this image) then seed a real server wiki so writes
+          # persist. "--init server" refuses a non-empty dir, so stage + move.
+          docker run --rm -v "$PWD/pvc:/data/wiki" busybox:1.36-musl \
+            sh -c 'chown -R 1000:1000 /data/wiki'
+          docker run --rm -u 1000 -v "$PWD/pvc:/data/wiki" --entrypoint node tiddlywiki5:smoke \
+            -e 'const fs=require("fs"),cp=require("child_process");const d="/data/wiki";if(!fs.existsSync(d+"/tiddlywiki.info")){const s=d+"/.tw-init";fs.mkdirSync(s,{recursive:true});cp.execFileSync(process.execPath,["./tiddlywiki.js",s,"--init","server"],{stdio:"inherit"});for(const f of fs.readdirSync(s))fs.renameSync(s+"/"+f,d+"/"+f);fs.rmdirSync(s);}'
+
+      - name: Start container exactly as the chart renders it
+        run: |
+          # ENTRYPOINT=dumb-init, command=wiki.command, args=dataPath + --listen.
+          docker run -d --name tw -u 1000 -p 8080:8080 \
+            -v "$PWD/pvc:/data/wiki" \
+            tiddlywiki5:smoke \
+            node ./tiddlywiki.js /data/wiki --listen host=0.0.0.0 port=8080 gzip=yes use-browser-cache=yes
+
+      - name: Wait for /status (fail fast on crash-loop)
+        run: |
+          for i in $(seq 1 30); do
+            if curl -fsS http://localhost:8080/status >/tmp/status.json 2>/dev/null; then
+              echo "status: $(cat /tmp/status.json)"
+              if docker logs tw 2>&1 | grep -q "Plugin(s) required for client-server operation are missing"; then
+                echo "::error::server started without filesystem/tiddlyweb plugins — fresh PVC not seeded"
+                docker logs tw; exit 1
+              fi
+              exit 0
+            fi
+            if [ "$(docker inspect -f '{{.State.Running}}' tw 2>/dev/null)" != "true" ]; then
+              echo "::error::container exited before serving /status"
+              docker logs tw; exit 1
+            fi
+            sleep 2
+          done
+          echo "::error::/status never became ready"
+          docker logs tw; exit 1
+
+      - name: Dump logs on failure
+        if: failure()
+        run: docker logs tw || true
+
   build-and-push:
+    needs: smoke-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/helm/tiddlywiki/Chart.yaml
+++ b/helm/tiddlywiki/Chart.yaml
@@ -2,8 +2,15 @@ apiVersion: v2
 name: tiddlywiki
 description: TiddlyWiki5 personal wiki server
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "5.4.0"
+
+# 0.1.1 — Fix crash-loop ("[dumb-init] /data/wiki: Permission denied"): the
+#   image ENTRYPOINT is dumb-init and the "node ./tiddlywiki.js" invocation
+#   lived only in CMD, which Kubernetes args replace. The chart now sets an
+#   explicit command (wiki.command). Also seed a persistent server wiki on a
+#   fresh PVC via an initContainer (wiki.initOnEmpty), tolerating the ext4
+#   lost+found dir, and align initContainer chown with podSecurityContext.runAsUser.
 
 keywords:
   - wiki

--- a/helm/tiddlywiki/templates/deployment.yaml
+++ b/helm/tiddlywiki/templates/deployment.yaml
@@ -45,9 +45,16 @@ spec:
       {{- end }}
 
       # -------------------------------------------------------
-      # Init container: seed /data/wiki with correct ownership.
-      # Distroless has no shell, so busybox does the mkdir/chown.
+      # Init containers.
+      # 1. init-wiki-dir: create the data dirs and hand the volume to the
+      #    runtime user. Runs as root (busybox) so it can chown a freshly
+      #    provisioned PVC. The uid/gid track podSecurityContext.runAsUser so
+      #    the seed and main containers can write under readOnlyRootFilesystem.
+      # 2. seed-wiki (optional): lay down a real server wiki the first time so
+      #    a fresh PVC can actually persist tiddlers. See notes on the step.
       # -------------------------------------------------------
+      {{- $uid := .Values.podSecurityContext.runAsUser | default 1000 }}
+      {{- $gid := .Values.podSecurityContext.runAsGroup | default $uid }}
       initContainers:
         - name: init-wiki-dir
           image: busybox:1.36-musl
@@ -60,7 +67,7 @@ spec:
               mkdir -p {{ $.Values.wiki.dataPath }}/plugins/{{ .name }}
               cp -r /plugins/{{ .name }}/. {{ $.Values.wiki.dataPath }}/plugins/{{ .name }}/
               {{- end }}
-              chown -R 65532:65532 {{ .Values.wiki.dataPath }}
+              chown -R {{ $uid }}:{{ $gid }} {{ .Values.wiki.dataPath }}
           volumeMounts:
             - name: wiki-data
               mountPath: {{ .Values.wiki.dataPath }}
@@ -78,6 +85,40 @@ spec:
               drop: ["ALL"]
               add: ["CHOWN", "DAC_OVERRIDE"]
 
+        # Seed a real server wiki (tiddlywiki.info + filesystem/tiddlyweb
+        # plugins) on first start only. Without it a fresh PVC serves but warns
+        # the required plugins are missing and silently drops writes. A freshly
+        # provisioned ext4 PVC also contains a lost+found dir, and "--init
+        # server" refuses a non-empty folder ("Wiki folder is not empty"), so we
+        # init into a staging dir and move the result into place. Idempotent:
+        # no-op once tiddlywiki.info exists. Runs as the runtime user, after the
+        # chown above, using the app image (which has node + a shell).
+        {{- if .Values.wiki.initOnEmpty }}
+        - name: seed-wiki
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - {{ index .Values.wiki.command 0 | quote }}
+          args:
+            - "-e"
+            - |
+              const fs = require('fs'), cp = require('child_process');
+              const data = {{ .Values.wiki.dataPath | quote }};
+              if (fs.existsSync(data + '/tiddlywiki.info')) { console.log('wiki already initialised'); process.exit(0); }
+              const stage = data + '/.tw-init';
+              fs.rmSync(stage, {recursive:true, force:true});
+              fs.mkdirSync(stage, {recursive:true});
+              cp.execFileSync(process.execPath, ['./tiddlywiki.js', stage, '--init', 'server'], {stdio:'inherit'});
+              for (const f of fs.readdirSync(stage)) fs.renameSync(stage + '/' + f, data + '/' + f);
+              fs.rmdirSync(stage);
+              console.log('initialised server wiki at ' + data);
+          volumeMounts:
+            - name: wiki-data
+              mountPath: {{ .Values.wiki.dataPath }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+        {{- end }}
+
       containers:
         # -------------------------------------------------------
         # Main: TiddlyWiki server
@@ -86,7 +127,14 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
 
-          # ENTRYPOINT = ["/nodejs/bin/node", "tiddlywiki.js"] (Dockerfile)
+          # The image ENTRYPOINT is ["/usr/bin/dumb-init", "--"] and the
+          # "node ./tiddlywiki.js" invocation lives only in the image CMD.
+          # Kubernetes args REPLACE CMD, so without an explicit command the
+          # container would run `dumb-init -- /data/wiki --listen ...` and try
+          # to exec the data directory -> "Permission denied" crash-loop.
+          # Set command explicitly so the chart is correct regardless of CMD.
+          command:
+            {{- toYaml .Values.wiki.command | nindent 12 }}
           args:
             - {{ .Values.wiki.dataPath | quote }}
             - "--listen"

--- a/helm/tiddlywiki/values.yaml
+++ b/helm/tiddlywiki/values.yaml
@@ -18,10 +18,26 @@ replicaCount: 1
 # TiddlyWiki server configuration
 # =============================================================================
 wiki:
+  # -- Executable + leading args, set as the pod's `command:`. The image
+  # ENTRYPOINT (dumb-init) does NOT include "node ./tiddlywiki.js" — that lives
+  # only in the image CMD, which Kubernetes args replace. Setting command here
+  # makes the chart correct regardless of the image CMD. The image WORKDIR is
+  # /usr/src/app with node on PATH. dataPath + --listen flags are appended as args.
+  command:
+    - node
+    - ./tiddlywiki.js
+
   # -- Path inside the container to serve.
-  # /app/editions/server = bundled demo (no PVC needed, resets on upgrade).
-  # /data/wiki           = persistent user wiki (requires PVC).
+  # ./editions/server = bundled demo (no PVC needed, resets on upgrade).
+  # /data/wiki        = persistent user wiki (requires PVC).
   dataPath: /data/wiki
+
+  # -- Seed a real server wiki (tiddlywiki.info + filesystem/tiddlyweb plugins)
+  # into dataPath on first start if none exists, via an initContainer. Without
+  # it, a fresh PVC serves but cannot persist writes (required plugins missing).
+  # No-op once a wiki is present, and tolerant of the lost+found dir on ext4.
+  # Set false if you pre-populate the volume yourself (e.g. git-sync restore).
+  initOnEmpty: true
 
   # -- Server port (container-internal)
   port: 8080


### PR DESCRIPTION
## Problem

Chart `tiddlywiki` v0.1.0 crash-loops with **`[dumb-init] /data/wiki: Permission denied`**.

The published image `ghcr.io/mibmal/tiddlywiki5:latest` has:

```
ENTRYPOINT ["/usr/bin/dumb-init", "--"]
CMD ["node", "./tiddlywiki.js", "./editions/server", "--listen", "host=0.0.0.0"]
```

The Deployment renders the main container with **no `command:`** and `args: ["/data/wiki", "--listen", ...]`. Kubernetes args **replace** the image CMD, so the container runs:

```
dumb-init -- /data/wiki --listen host=0.0.0.0 ...
```

dumb-init then tries to exec the directory `/data/wiki` as a program → `Permission denied`, and the pod crash-loops. The `node ./tiddlywiki.js` invocation is gone because it only ever lived in CMD.

(The `# ENTRYPOINT = ["/nodejs/bin/node", "tiddlywiki.js"]` comment in the template was stale — it described an earlier distroless draft, not the dumb-init image actually published.)

## Fix

- **`wiki.command`** (default `["node", "./tiddlywiki.js"]`) is now set as the container `command`, so the full invocation is `dumb-init -- node ./tiddlywiki.js /data/wiki --listen ...` regardless of the image CMD. Overridable via values.
- **`wiki.initOnEmpty`** (default `true`): an initContainer seeds a real server wiki (`tiddlywiki.info` + `filesystem`/`tiddlyweb` plugins) on first start. Without it a fresh PVC serves but warns the required plugins are missing and **silently drops writes**. `--init server` refuses a non-empty dir, so we init into a staging subdir and move into place — tolerating the **`lost+found`** directory present on a freshly provisioned ext4 PVC. Idempotent (no-op once `tiddlywiki.info` exists).
- The initContainer **chown** uid/gid now tracks `podSecurityContext.runAsUser` instead of a hardcoded `65532`.
- **CI smoke test** (`ghcr-publish.yml`): builds the `run` stage, simulates a fresh ext4 PVC (with `lost+found`), starts the container exactly as the chart renders it, and asserts `/status` answers and the required plugins loaded. The publish job now `needs:` this — so this class of entrypoint/seed regression can't ship again.
- Chart `0.1.0` → `0.1.1`.

## Verification

- `helm lint` passes; `helm template` renders `command: [node, ./tiddlywiki.js]` + `args: [/data/wiki, --listen, ...]`.
- `wiki.initOnEmpty=false` removes the seed initContainer; `podSecurityContext.runAsUser=1000` renders `chown -R 1000:1000`.
- The seed script was validated locally against a dir containing `lost+found`: it initialises a persistent wiki, is idempotent, and the server then starts with no missing-plugin warnings and actively persists tiddlers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)