### PR TITLE
ci(helm): publish chart via gh-pages index (fix immutable-release 422)

### DIFF
--- a/.github/workflows/helm-publish.yml
+++ b/.github/workflows/helm-publish.yml
@@ -34,10 +34,16 @@ jobs:
         with:
           version: "v3.16.4"
 
-      # chart-releaser packages charts found in ./helm/,
-      # pushes releases to GitHub Releases, and updates the
-      # index on the gh-pages branch so the repo doubles as a
-      # Helm chart repository.
+      # chart-releaser packages charts found in ./helm/ and updates the Helm
+      # repo index on the gh-pages branch so the repo doubles as a Helm chart
+      # repository.
+      #
+      # packages_with_index: host the packaged .tgz IN the gh-pages branch
+      # alongside index.yaml, instead of attaching it as a GitHub Release asset.
+      # GitHub immutable releases freeze assets at creation time, so the
+      # default create-release-then-upload-asset flow fails with
+      # "422 Cannot upload assets to an immutable release". Hosting the package
+      # on gh-pages sidesteps releases entirely and keeps the install URL the same.
       #
       # Usage after setup:
       #   helm repo add mibmal https://mibmal.github.io/TiddlyWiki5
@@ -47,6 +53,8 @@ jobs:
         uses: helm/chart-releaser-action@v1.6.0
         with:
           charts_dir: helm
+          packages_with_index: true
+          pages_branch: gh-pages
           # Skip already-released chart versions instead of failing.
           skip_existing: true
         env:


### PR DESCRIPTION
## Problem

The `Package & Publish Helm Chart` workflow failed on the 0.1.1 merge:

```
422 Cannot upload assets to an immutable release
```

chart-releaser's default flow is *create GitHub Release → upload `.tgz` as a release asset*. With **immutable releases** enabled, assets are frozen at release creation, so the upload fails — and it leaves a **stuck empty release** that `skip_existing: true` then skips on every re-run, so the chart never actually publishes.

## Fix

- Set `packages_with_index: true` (+ `pages_branch: gh-pages`) so the packaged `.tgz` is hosted **in the gh-pages index** alongside `index.yaml`, instead of as a GitHub Release asset. This avoids GitHub Releases entirely, so immutable releases are no longer in the path.
- The install URL is unchanged: `helm repo add mibmal https://mibmal.github.io/TiddlyWiki5`.
- The stuck empty `tiddlywiki-0.1.1` release + tag were deleted so this run recreates the index entry cleanly.

Verified `packages_with_index`/`pages_branch` are valid inputs in `chart-releaser-action@v1.6.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)