### PR TITLE
fix(ci): update docker actions to Node.js 24, fix Dockerfile casing, add version tag

### DIFF
--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -35,10 +35,10 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Build run stage (loaded locally)
-        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           target: run
@@ -99,27 +99,32 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Read TiddlyWiki version
+        id: tw_version
+        run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+
       - name: Docker metadata
         id: meta
-        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: ghcr.io/${{ github.repository_owner }}/tiddlywiki5
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=${{ steps.tw_version.outputs.version }},enable={{is_default_branch}}
             type=ref,event=tag
             type=sha,format=short
 
       - name: Build and push (run stage only)
-        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           target: run

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG NODE_VERSION=21.6.0
 ARG WIKI_NAME="mywiki"
 
 # Base Image
-FROM node:${NODE_VERSION}-alpine as base
+FROM node:${NODE_VERSION}-alpine AS base
 WORKDIR /usr/src/app
 RUN apk add dumb-init
 RUN apk add curl
@@ -11,7 +11,7 @@ RUN npm install
 COPY . /usr/src/app/
 
 # Playwright Tests
-FROM mcr.microsoft.com/playwright:focal as playwright-tests
+FROM mcr.microsoft.com/playwright:focal AS playwright-tests
 ENV CI=true
 WORKDIR /usr/src/app
 COPY package*.json ./
@@ -23,13 +23,13 @@ RUN npm install
 RUN npx playwright install
 
 #Jasmine Tests
-FROM base as jasmine-tests
+FROM base AS jasmine-tests
 RUN apk add chromium
 ENV CHROME_BIN=/usr/bin/chromium-browser
 RUN npm run test
 
 #Run TiddlyWiki
-FROM base as run
+FROM base AS run
 EXPOSE 8080
 COPY --from=base /usr/bin/dumb-init /usr/bin/dumb-init
 USER node
@@ -37,4 +37,4 @@ WORKDIR /usr/src/app
 COPY --chown=node:node --from=base /usr/src/app/node_modules /usr/src/app/node_modules
 COPY --chown=node:node . /usr/src/app
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
-CMD ["node", "./tiddlywiki.js", "./editions/server", "--listen", "host=0.0.0.0"] 
+CMD ["node", "./tiddlywiki.js", "./editions/server", "--listen", "host=0.0.0.0"]


### PR DESCRIPTION
## Summary

- **Node.js 24 actions**: Bump all docker GitHub Actions to Node.js 24-compatible versions before the June 16th forced migration deadline
  - `docker/setup-buildx-action` v3.11.1 → v4.1.0
  - `docker/build-push-action` v6.15.0 → v7.2.0
  - `docker/login-action` v3.6.0 → v4.2.0
  - `docker/metadata-action` v5.7.0 → v6.1.0
- **Dockerfile casing**: Fix all `FROM ... as` → `FROM ... AS` (Docker linter `FromAsCasing` violations)
- **Version tag**: Image is now tagged with the TiddlyWiki version from `package.json` (e.g. `5.4.1-prerelease`) on every master push, alongside `latest` and the git SHA

## Image tags after merge

Every push to `master` will produce:
- `ghcr.io/mibmal/tiddlywiki5:latest`
- `ghcr.io/mibmal/tiddlywiki5:5.4.1-prerelease`
- `ghcr.io/mibmal/tiddlywiki5:sha-abc1234`

## Test plan

- [ ] Confirm CI passes with no Node.js 20 deprecation warnings
- [ ] Confirm no `FromAsCasing` Dockerfile lint errors
- [ ] Confirm image is tagged with version after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)