### PR TITLE
fix(helm): fix startup/readiness probes when oauth2-proxy is enabled

### DIFF
--- a/helm/tiddlywiki/templates/deployment.yaml
+++ b/helm/tiddlywiki/templates/deployment.yaml
@@ -187,6 +187,30 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
 
+          {{- if .Values.oauth2Proxy.enabled }}
+          {{/* When oauth2-proxy is enabled, /status requires auth. Probe the
+               proxy's unauthenticated /ping endpoint instead. */}}
+          startupProbe:
+            httpGet:
+              path: /ping
+              port: {{ .Values.oauth2Proxy.port }}
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 12
+          livenessProbe:
+            httpGet:
+              path: /ping
+              port: {{ .Values.oauth2Proxy.port }}
+            periodSeconds: 30
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /ping
+              port: {{ .Values.oauth2Proxy.port }}
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 3
+          {{- else }}
           {{- with .Values.startupProbe }}
           startupProbe:
             {{- toYaml . | nindent 12 }}
@@ -200,6 +224,7 @@ spec:
           {{- with .Values.readinessProbe }}
           readinessProbe:
             {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- end }}
 
           {{- with .Values.securityContext }}
@@ -279,6 +304,13 @@ spec:
             readOnlyRootFilesystem: true
             capabilities:
               drop: ["ALL"]
+          startupProbe:
+            httpGet:
+              path: /ping
+              port: proxy
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 12
           livenessProbe:
             httpGet:
               path: /ping
@@ -289,6 +321,7 @@ spec:
             httpGet:
               path: /ping
               port: proxy
+            initialDelaySeconds: 5
             periodSeconds: 10
             failureThreshold: 3
           volumeMounts:


### PR DESCRIPTION
## Problems

**Connection refused on port 4180** — the oauth2-proxy sidecar had no `startupProbe` and no `initialDelaySeconds` on its readiness probe, so Kubernetes probed it immediately before it had started listening.

**401 on startup probe** — the main container probes hit `/status` on port 8080. When `auth.readers=(authenticated)`, TiddlyWiki correctly returns 401 to unauthenticated requests — which fails the probe.

## Fix

When `oauth2Proxy.enabled=true`:
- All main container probes (`startup`, `liveness`, `readiness`) are redirected to oauth2-proxy's `/ping` endpoint, which is always unauthenticated
- oauth2-proxy sidecar gets a `startupProbe` and `initialDelaySeconds` on its readiness probe

When `oauth2Proxy.enabled=false`, behaviour is unchanged — probes use the values from `values.yaml` as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)