### PR TITLE
fix(ci): break infinite loop — skip bump-chart when pushed by bot

### DIFF
--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -164,7 +164,9 @@ jobs:
   bump-chart:
     needs: build-and-push
     runs-on: ubuntu-latest
-    if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+    if: |
+      github.ref == format('refs/heads/{0}', github.event.repository.default_branch) &&
+      github.actor != 'github-actions[bot]'
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Problem

Merging the auto-generated chart bump PR triggers another push to `master`, which runs `ghcr-publish`, which opens another chart bump PR, which when merged triggers another push... infinite loop.

## Fix

Skip the `bump-chart` job when `github.actor == 'github-actions[bot]'` — i.e. when the push was the bot merging its own PR. Human pushes and PR merges still trigger it as normal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)