### PR TITLE
Improve CORS handling for cross-origin / proxied deployments

### DIFF
--- a/core-server/server/server.js
+++ b/core-server/server/server.js
@@ -279,6 +279,15 @@ Server.prototype.requestHandler = function(request,response,options) {
 		response.end();
 		return;
 	}
+	// Reply to CORS preflight OPTIONS requests before authenticating. Browsers send
+	// preflights without credentials by design, so requiring authentication here would
+	// cause the preflight to fail with a 401 and the CORS headers set above would not be
+	// honoured by the browser.
+	if(this.corsEnable && request.method === "OPTIONS") {
+		response.writeHead(204);
+		response.end();
+		return;
+	}
 	// Check whether anonymous access is granted
 	state.allowAnon = this.isAuthorized(state.authorizationType,null);
 	// Authenticate with the first active authenticator
@@ -291,12 +300,6 @@ Server.prototype.requestHandler = function(request,response,options) {
 	// Authorize with the authenticated username
 	if(!this.isAuthorized(state.authorizationType,state.authenticatedUsername)) {
 		response.writeHead(401,"'" + state.authenticatedUsername + "' is not authorized to access '" + this.servername + "'");
-		response.end();
-		return;
-	}
-	// Reply to OPTIONS
-	if(this.corsEnable && request.method === "OPTIONS") {
-		response.writeHead(204);
 		response.end();
 		return;
 	}

--- a/core/modules/utils/dom/http.js
+++ b/core/modules/utils/dom/http.js
@@ -267,8 +267,12 @@ exports.httpRequest = function(options) {
 					return false;
 				}
 			}
-			if(hasHeader("Content-Type") && ["application/x-www-form-urlencoded","multipart/form-data","text/plain"].indexOf(getHeader["Content-Type"]) === -1) {
-				return false;
+			if(hasHeader("Content-Type")) {
+				// Strip any parameters (eg "; charset=UTF-8") before comparing the MIME type
+				var contentType = (getHeader("Content-Type") || "").split(";")[0].trim().toLowerCase();
+				if(["application/x-www-form-urlencoded","multipart/form-data","text/plain"].indexOf(contentType) === -1) {
+					return false;
+				}
 			}
 			return true;
 		},


### PR DESCRIPTION
- server.js: answer CORS preflight OPTIONS requests before running the
  authenticate/authorize steps. Browsers send preflights without
  credentials, so requiring auth made the preflight fail with a 401
  (and the CORS headers were never honoured by the browser).

- http.js: fix isSimpleRequest() Content-Type check. getHeader was being
  indexed as an object instead of called, so it always returned undefined
  and every request carrying a Content-Type header was misclassified as
  non-simple. This added X-Requested-With and forced an unnecessary CORS
  preflight. Now the MIME type is read correctly and compared with any
  charset parameter stripped.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LKSDpxz9YKLEuGRNiHLrUJ