### PR TITLE
feat(helm): MWS multi-tenant mode for the chart

### DIFF
--- a/helm/tiddlywiki/templates/deployment.yaml
+++ b/helm/tiddlywiki/templates/deployment.yaml
@@ -127,6 +127,13 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
 
+          {{- if eq .Values.wiki.mode "mws" }}
+          # MWS mode: the image ENTRYPOINT (docker-entrypoint.sh) wires SQLite
+          # state onto the volume and runs `init-store` on first boot, so we
+          # leave command unset and pass only the MWS listen args.
+          args:
+            {{- toYaml .Values.wiki.mwsArgs | nindent 12 }}
+          {{- else }}
           # The image ENTRYPOINT is ["/usr/bin/dumb-init", "--"] and the
           # "node ./tiddlywiki.js" invocation lives only in the image CMD.
           # Kubernetes args REPLACE CMD, so without an explicit command the
@@ -139,6 +146,7 @@ spec:
             - {{ .Values.wiki.dataPath | quote }}
             - "--listen"
             {{- include "tiddlywiki.listenArgs" . | nindent 12 }}
+          {{- end }}
 
           ports:
             - name: http

--- a/helm/tiddlywiki/values-mws.yaml
+++ b/helm/tiddlywiki/values-mws.yaml
@@ -1,0 +1,46 @@
+# Example values for running the chart in Multi-Wiki Server (MWS) + SSO mode.
+#   helm upgrade --install tw ./helm/tiddlywiki -f helm/tiddlywiki/values-mws.yaml
+#
+# MWS is multi-tenant: each SSO user gets an isolated personal wiki, and bags can
+# be shared with members or teams (see the mws-app SSO adapter). SQLite is
+# single-writer, so this stays at replicaCount 1 / strategy Recreate / no HPA
+# (already the chart defaults). The git-sync/snapshot cronjobs (flat-file) do not
+# apply; back up the SQLite store instead (e.g. Litestream).
+
+image:
+  # Build from mws-app/Dockerfile and push to your registry.
+  repository: ghcr.io/mibmal/tiddlywiki-mws
+  tag: "0.1.14-sso"
+
+replicaCount: 1          # SQLite single-writer — do not scale the writer
+# strategy.type defaults to Recreate; autoscaling defaults to disabled — leave as-is.
+
+wiki:
+  mode: mws
+  dataPath: /data        # PVC mount; MWS keeps store/ + passwords.key here
+  initOnEmpty: false     # the MWS image entrypoint runs init-store itself
+  port: 8080
+
+persistence:
+  enabled: true
+  size: 10Gi
+
+# SSO adapter configuration (consumed by mws-app/sso/config.mjs).
+extraEnv:
+  - { name: MWS_DATA_DIR, value: /data }
+  - { name: MWS_SSO_ENABLED, value: "true" }
+  - { name: MWS_SSO_EMAIL_HEADER, value: x-auth-request-email }
+  # Admin-controlled default plugin list seeded into each new personal wiki:
+  - name: MWS_SSO_DEFAULT_PLUGINS
+    value: "$:/plugins/tiddlywiki/tiddlyweb,$:/plugins/tiddlywiki/menubar,$:/plugins/tiddlywiki/codemirror"
+
+# Auth perimeter. oauth2-proxy authenticates against the IdP and forwards
+# X-Auth-Request-Email (via --set-xauthrequest, already set by the chart), which
+# the SSO adapter turns into a per-user MWS login.
+oauth2Proxy:
+  enabled: true
+  provider: oidc
+  oidcIssuerUrl: "https://idp.example.com/"
+  emailDomain: "*"
+  # Provide client-id/secret/cookie-secret via a Secret managed outside the chart.
+  existingSecret: "mws-oauth2"

--- a/helm/tiddlywiki/values.yaml
+++ b/helm/tiddlywiki/values.yaml
@@ -18,6 +18,20 @@ replicaCount: 1
 # TiddlyWiki server configuration
 # =============================================================================
 wiki:
+  # -- Server flavour: "classic" (single-wiki node server, the default) or
+  # "mws" (Multi-Wiki Server + SSO adapter image). In mws mode the image
+  # ENTRYPOINT handles state setup + init-store, `command` is not set, and
+  # `mwsArgs` below are passed as args. See values-mws.yaml for a full example.
+  mode: classic
+
+  # -- Args passed to the MWS image ENTRYPOINT when mode=mws (ignored otherwise).
+  mwsArgs:
+    - listen
+    - --listener
+    - host=0.0.0.0
+    - port=8080
+    - secure=true
+
   # -- Executable + leading args, set as the pod's `command:`. The image
   # ENTRYPOINT (dumb-init) does NOT include "node ./tiddlywiki.js" — that lives
   # only in the image CMD, which Kubernetes args replace. Setting command here


### PR DESCRIPTION
Adds an additive `wiki.mode` (default `classic`, unchanged) plus an `mws` flavour that runs the Multi-Wiki Server + SSO adapter image (per-user spaces, sharing, teams). In `mws` mode the image ENTRYPOINT handles state setup + init-store, so the chart sets only `wiki.mwsArgs`. Ships `values-mws.yaml` (SQLite single-writer: replicas 1 / Recreate; oauth2-proxy OIDC perimeter forwarding X-Auth-Request-Email; admin-controlled default plugin list).

Validated with `helm lint` + `helm template` (both modes render correctly; classic output unchanged).

Note: this is the deployment plumbing. The SSO adapter it points at was proven end-to-end as a spike (P1 isolated spaces + P2 share + P3 teams) and is being re-homed natively into the MWS fork.

🤖 Generated with [Claude Code](https://claude.com/claude-code)